### PR TITLE
Add MQTT configuration file and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,5 @@ This file records design decisions and requirements for the PubObs website.
 14. README must include mermaid diagrams explaining the site and instructions on updating the website.
 
 Design decisions added after this file should be appended here for future reference.
+
+15. MQTT host and topic names are stored in `mqtt_config.json`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views and shows a live updating graph
 
+## Configuration
+
+MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
+
 ## Architecture
 
 ```mermaid

--- a/mqtt_config.json
+++ b/mqtt_config.json
@@ -1,0 +1,13 @@
+{
+  "host": "localhost",
+  "topics": {
+    "temperature": "Observatory/temp",
+    "rain": "Observatory/rain",
+    "light": "Observatory/light",
+    "clouds": "Observatory/clouds",
+    "safe": "Observatory/safe",
+    "sqm": "Observatory/sqm",
+    "humidity": "Observatory/hum",
+    "dewpoint": "Observatory/dewp"
+  }
+}


### PR DESCRIPTION
## Summary
- document MQTT host and topics in dedicated configuration file
- explain how to customize MQTT settings in README
- record MQTT configuration decision in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1389080e8832e819ab16bddb002a9