### PR TITLE
Add initial PubObs website with live and historical sensor views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,6 @@ This file records design decisions and requirements for the PubObs website.
 Design decisions added after this file should be appended here for future reference.
 
 15. MQTT host and topic names are stored in `mqtt_config.json`.
+16. The website uses the Paho JavaScript client to subscribe to MQTT topics over WebSockets on port 9001.
+17. Historical data resides in a MySQL table named `sensor_data` with columns `topic`, `timestamp`, and `value`.
+18. Database credentials are read from the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Website that publicly shows observatory sensor data. The site displays live and 
 
 MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
 
+Database credentials are provided to Apache via environment variables:
+
+- `DB_HOST`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASS`
+
+## Site Pages
+
+```mermaid
+flowchart LR
+    Index["index.php"] --> Hist["historical.php"]
+```
+
 ## Architecture
 
 ```mermaid

--- a/historical.php
+++ b/historical.php
@@ -1,0 +1,67 @@
+<?php
+$config = json_decode(file_get_contents('mqtt_config.json'), true);
+$topics = $config['topics'] ?? [];
+$key = $_GET['topic'] ?? '';
+if (!array_key_exists($key, $topics)) {
+    http_response_code(404);
+    echo 'Unknown topic';
+    exit;
+}
+$dbHost = getenv('DB_HOST');
+$dbName = getenv('DB_NAME');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+try {
+    $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $stmt = $pdo->prepare('SELECT timestamp, value FROM sensor_data WHERE topic = ? ORDER BY timestamp DESC LIMIT 100');
+    $stmt->execute([$key]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (Exception $e) {
+    $rows = [];
+}
+?>
+<!DOCTYPE html>
+<html class="h-full" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>History: <?php echo htmlspecialchars($key); ?></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <link href="https://unpkg.com/tabulator-tables@5.4.4/dist/css/tabulator.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>
+</head>
+<body class="h-full bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+    <div class="container mx-auto p-4">
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
+            <button id="modeToggle" class="px-2 py-1 border rounded">Toggle Mode</button>
+        </div>
+        <div id="histChart" class="mb-6"></div>
+        <div id="histTable"></div>
+    </div>
+
+    <script>
+    const modeToggle = document.getElementById('modeToggle');
+    modeToggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+    });
+    const data = <?php echo json_encode($rows); ?>;
+    const chartData = data.map(r => [Date.parse(r.timestamp), parseFloat(r.value)]).reverse();
+    Highcharts.chart('histChart', {
+        chart: { type: 'line' },
+        title: { text: 'Historical Data' },
+        xAxis: { type: 'datetime' },
+        series: [{ name: <?php echo json_encode($key); ?>, data: chartData }]
+    });
+    new Tabulator('#histTable', {
+        data: data,
+        layout: 'fitColumns',
+        columns: [
+            { title: 'Timestamp', field: 'timestamp' },
+            { title: 'Value', field: 'value' }
+        ]
+    });
+    </script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,97 @@
+<?php
+$config = json_decode(file_get_contents('mqtt_config.json'), true);
+$host = $config['host'] ?? 'localhost';
+$topics = $config['topics'] ?? [];
+?>
+<!DOCTYPE html>
+<html class="h-full" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PubObs Live Data</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Highcharts -->
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <!-- Tabulator -->
+    <link href="https://unpkg.com/tabulator-tables@5.4.4/dist/css/tabulator.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>
+    <!-- MQTT over WebSocket -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.1.0/mqttws31.min.js"></script>
+</head>
+<body class="h-full bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+    <div class="container mx-auto p-4">
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-2xl font-bold">PubObs Live Data</h1>
+            <button id="modeToggle" class="px-2 py-1 border rounded">Toggle Mode</button>
+        </div>
+        <div id="topic-table"></div>
+        <div class="mt-6">
+            <label for="topicSelect" class="block mb-2">Select Topic:</label>
+            <select id="topicSelect" class="text-black rounded p-2">
+            <?php foreach($topics as $key => $topic): ?>
+                <option value="<?php echo htmlspecialchars($topic); ?>"><?php echo htmlspecialchars($key); ?></option>
+            <?php endforeach; ?>
+            </select>
+        </div>
+        <div id="liveChart" class="mt-6"></div>
+    </div>
+
+    <script>
+    const topics = <?php echo json_encode($topics); ?>;
+    const tableData = Object.keys(topics).map(key => ({topic: key, link: `<a class=\"text-blue-500\" href=\"historical.php?topic=${key}\">History</a>`}));
+    const table = new Tabulator("#topic-table", {
+        data: tableData,
+        layout: "fitColumns",
+        columns:[
+            {title:"Topic", field:"topic"},
+            {title:"Historical", field:"link", formatter:"html"}
+        ]
+    });
+
+    const modeToggle = document.getElementById('modeToggle');
+    modeToggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+    });
+
+    const host = <?php echo json_encode($host); ?>;
+    const port = 9001; // default WebSocket port for MQTT
+    const client = new Paho.MQTT.Client(host, port, "webclient-" + Math.random());
+
+    function onConnectionLost() {
+        console.log('Connection lost');
+    }
+    function onMessageArrived(message) {
+        const value = parseFloat(message.payloadString);
+        const x = (new Date()).getTime();
+        chart.series[0].addPoint([x, value], true, chart.series[0].data.length > 40);
+    }
+
+    client.onConnectionLost = onConnectionLost;
+    client.onMessageArrived = onMessageArrived;
+
+    client.connect({onSuccess: () => {
+        const selectedTopic = document.getElementById('topicSelect').value;
+        client.subscribe(selectedTopic);
+    }});
+
+    const chart = Highcharts.chart('liveChart', {
+        chart: {
+            type: 'spline'
+        },
+        title: { text: 'Live Sensor Data' },
+        xAxis: { type: 'datetime' },
+        series: [{ name: 'Value', data: [] }]
+    });
+
+    document.getElementById('topicSelect').addEventListener('change', function(e){
+        const newTopic = e.target.value;
+        for (const t of Object.values(topics)) {
+            client.unsubscribe(t);
+        }
+        chart.series[0].setData([]);
+        client.subscribe(newTopic);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build `index.php` with Tailwind styles, MQTT live updates via Paho, Highcharts graph, and Tabulator topic table
- Add `historical.php` to query MySQL using environment credentials and display data using Highcharts and Tabulator
- Document configuration, page structure, and database env vars in README; record new design decisions in AGENTS

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c143cc7f44832eb41634fc158f5b5c