### PR TITLE
Use MQTT WebSocket port 8083

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,6 @@ This file records design decisions and requirements for the PubObs website.
 Design decisions added after this file should be appended here for future reference.
 
 15. MQTT host and topic names are stored in `mqtt_config.json`.
-16. The website uses the Paho JavaScript client to subscribe to MQTT topics over WebSockets on port 9001.
+16. The website uses the Paho JavaScript client to subscribe to MQTT topics over WebSockets on port 8083.
 17. Historical data resides in a MySQL table named `sensor_data` with columns `topic`, `timestamp`, and `value`.
 18. Database credentials are read from the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 ## Configuration
 
 MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
+The MQTT WebSocket port is 8083.
 
 Database credentials are provided to Apache via environment variables:
 

--- a/index.php
+++ b/index.php
@@ -55,7 +55,7 @@ $topics = $config['topics'] ?? [];
     });
 
     const host = <?php echo json_encode($host); ?>;
-    const port = 9001; // default WebSocket port for MQTT
+    const port = 8083; // default WebSocket port for MQTT
     const client = new Paho.MQTT.Client(host, port, "webclient-" + Math.random());
 
     function onConnectionLost() {


### PR DESCRIPTION
## Summary
- Update Paho MQTT WebSocket port to 8083 in live data client
- Document new MQTT WebSocket port in project instructions and README

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c146b71d74832e9b5f6b014bcd080e