### PR TITLE
Use obs_weather table for historical data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,4 @@ Design decisions added after this file should be appended here for future refere
 16. The website uses the Paho JavaScript client to subscribe to MQTT topics over WebSockets on port 8083.
 17. Historical data resides in a MySQL table named `sensor_data` with columns `topic`, `timestamp`, and `value`.
 18. Database credentials are read from the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`.
+19. Historical weather data is now stored in a MySQL table named `obs_weather` with columns `dateTime`, `clouds`, `temp`, `wind`, `gust`, `rain`, `light`, `switch`, `safe`, `hum`, and `dewp`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 ## Features
 
 - Live data via MQTT
-- Historical data stored in a local MySQL database
+ - Historical data stored in a local MySQL table `obs_weather`
 - Highcharts for interactive graphs
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes


### PR DESCRIPTION
## Summary
- Map topic names to columns in new obs_weather table
- Query obs_weather for selected metric when rendering historical graphs
- Document obs_weather table and new design decision

## Testing
- `php -l historical.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c147c66fc0832ea1277db34ce8e5eb