### PR TITLE
Document Apache SetEnv variables for MySQL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Database credentials are provided to Apache via environment variables:
 - `DB_USER`
 - `DB_PASS`
 
+Set these variables in your Apache site configuration using `SetEnv` directives, for example:
+
+```
+SetEnv DB_HOST "localhost"
+SetEnv DB_NAME "pubobs"
+SetEnv DB_USER "pubobs_user"
+SetEnv DB_PASS "secret"
+```
+
 ## Site Pages
 
 ```mermaid


### PR DESCRIPTION
## Summary
- explain using Apache `SetEnv` directives to supply `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`

## Testing
- `php -l index.php historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c14a86ad80832e8705278eed61226f