### PR TITLE
Document light and SQM sensor tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@ Design decisions added after this file should be appended here for future refere
 17. Historical data resides in a MySQL table named `sensor_data` with columns `topic`, `timestamp`, and `value`.
 18. Database credentials are read from the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`.
 19. Historical weather data is now stored in a MySQL table named `obs_weather` with columns `dateTime`, `clouds`, `temp`, `wind`, `gust`, `rain`, `light`, `switch`, `safe`, `hum`, and `dewp`.
+20. A separate table `obs_light` stores light sensor readings with columns `dateTime` and `light`. SQM readings reside in the `light` column of `obs_weather`; combine data using SQL joins or unions at query time.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,45 @@ Website that publicly shows observatory sensor data. The site displays live and 
 ## Features
 
 - Live data via MQTT
- - Historical data stored in a local MySQL table `obs_weather`
+- Historical data stored in a local MySQL table `obs_weather`
 - Highcharts for interactive graphs
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views and shows a live updating graph
+
+## Sensor Data Tables
+
+- `obs_weather` stores weather readings, including SQM values in the `light` column.
+- `obs_light` stores readings from a separate light sensor with a `light` column.
+
+### Retrieve both sensors
+
+Use SQL joins or unions to combine the two tables without altering their schemas:
+
+```sql
+SELECT w.dateTime,
+       w.light AS sqm,
+       l.light AS light
+FROM obs_weather AS w
+JOIN obs_light   AS l
+      ON w.dateTime = l.dateTime
+ORDER BY w.dateTime DESC;
+```
+
+```sql
+SELECT dateTime,
+       'SQM'   AS sensor,
+       light   AS reading
+FROM obs_weather
+
+UNION ALL
+
+SELECT dateTime,
+       'Light',
+       light
+FROM obs_light
+ORDER BY dateTime DESC;
+```
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Document storage of SQM readings in `obs_weather` and light sensor data in `obs_light`
- Add SQL examples demonstrating join and union queries for combining both sensors
- Record new design decision about `obs_light` table in `AGENTS.md`

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c147f30970832eb66135a05f057f4e