### PR TITLE
Fix dark mode toggle by enabling Tailwind class mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,6 +11,11 @@ $topics = $config['topics'] ?? [];
     <title>PubObs Live Data</title>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+        }
+    </script>
     <!-- Highcharts -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <!-- Tabulator -->


### PR DESCRIPTION
## Summary
- Configure Tailwind to use class-based dark mode so the toggle button switches themes

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c14ca0b220832e87893a748dd22dd6