### PR TITLE
Add nightly observable hours chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,5 @@ Design decisions added after this file should be appended here for future refere
 19. Historical weather data is now stored in a MySQL table named `obs_weather` with columns `dateTime`, `clouds`, `temp`, `wind`, `gust`, `rain`, `light`, `switch`, `safe`, `hum`, and `dewp`.
 20. The index page displays current MQTT values in a responsive grid of Tailwind CSS cards.
 
+21. The index page shows a bar chart of nightly observable hours for the last 30 days using safe data from `obs_weather`.
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Highcharts for interactive graphs
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
-- Index page lists all live data sources with links to historical views and shows a live updating graph
+- Index page lists all live data sources with links to historical views, shows a live updating graph, and displays nightly observable hours from the past 30 days
 
 ## Sensor Data Tables
 

--- a/index.php
+++ b/index.php
@@ -2,6 +2,35 @@
 $config = json_decode(file_get_contents('mqtt_config.json'), true);
 $host = $config['host'] ?? 'localhost';
 $topics = $config['topics'] ?? [];
+
+$dbHost = getenv('DB_HOST');
+$dbName = getenv('DB_NAME');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+
+$safeData = [];
+try {
+    $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $stmt = $pdo->prepare("SELECT DATE(FROM_UNIXTIME(dateTime)) AS day, SUM(safe)/60 AS hours FROM obs_weather WHERE dateTime >= UNIX_TIMESTAMP(DATE_SUB(CURDATE(), INTERVAL 30 DAY)) GROUP BY day ORDER BY day");
+    $stmt->execute();
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $start = new DateTime('-29 days');
+    for ($i = 0; $i < 30; $i++) {
+        $d = clone $start;
+        $d->modify("+{$i} day");
+        $safeData[$d->format('Y-m-d')] = 0;
+    }
+    foreach ($rows as $row) {
+        $safeData[$row['day']] = round((float)$row['hours'], 2);
+    }
+    $tmp = [];
+    foreach ($safeData as $day => $hours) {
+        $tmp[] = ['day' => $day, 'hours' => $hours];
+    }
+    $safeData = $tmp;
+} catch (Exception $e) {
+    $safeData = [];
+}
 ?>
 <!DOCTYPE html>
 <html class="h-full" lang="en">
@@ -29,11 +58,13 @@ $topics = $config['topics'] ?? [];
         </div>
         <div id="cards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
         <div id="liveChart" class="mt-6"></div>
+        <div id="safeChart" class="mt-6"></div>
     </div>
 
     <script>
     const topics = <?php echo json_encode($topics); ?>;
     const host = <?php echo json_encode($host); ?>;
+    const safeData = <?php echo json_encode($safeData); ?>;
     const port = 8083; // default WebSocket port for MQTT
     const topicEntries = Object.entries(topics);
     let selectedName = topicEntries.length ? topicEntries[0][0] : '';
@@ -98,6 +129,16 @@ $topics = $config['topics'] ?? [];
         title: { text: selectedName ? 'Live Sensor Data: ' + selectedName : 'Live Sensor Data' },
         xAxis: { type: 'datetime' },
         series: [{ name: 'Value', data: [] }]
+    });
+
+    const safeCategories = safeData.map(r => r.day);
+    const safeHours = safeData.map(r => parseFloat(r.hours));
+    Highcharts.chart('safeChart', {
+        chart: { type: 'column' },
+        title: { text: 'Observable Hours (Last 30 Days)' },
+        xAxis: { categories: safeCategories },
+        yAxis: { title: { text: 'Hours' } },
+        series: [{ name: 'Hours', data: safeHours }]
     });
 
     const modeToggle = document.getElementById('modeToggle');


### PR DESCRIPTION
## Summary
- Aggregate `obs_weather.safe` readings to compute nightly observable hours for the past 30 days
- Display the aggregated hours in a Highcharts column chart on the index page
- Document new feature and design decision

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c157f0ac08832eacf65a6ceab22c4a