### PR TITLE
Handle missing Paho MQTT client gracefully

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,5 @@ Design decisions added after this file should be appended here for future refere
 
 
 21. The index page shows a bar chart of nightly observable hours for the last 30 days using safe data from `obs_weather`.
+22. If the Paho MQTT library fails to load, the index page should display an MQTT unavailable status and avoid runtime errors.
 

--- a/index.php
+++ b/index.php
@@ -116,7 +116,7 @@ const icons = {
     });
 
     const statusEl = document.getElementById('mqttStatus');
-    const client = new Paho.MQTT.Client(brokerHost, port, "webclient-" + Math.random());
+    let client;
 
     function onConnectionLost() {
         console.log('Connection lost');
@@ -148,10 +148,16 @@ const icons = {
         statusEl.className = 'text-sm text-red-600';
     }
 
-    client.onConnectionLost = onConnectionLost;
-    client.onMessageArrived = onMessageArrived;
-
-    client.connect({ onSuccess: onConnect, onFailure: onFail, useSSL: location.protocol === 'https:' });
+    if (typeof Paho !== 'undefined' && Paho.MQTT && Paho.MQTT.Client) {
+        client = new Paho.MQTT.Client(brokerHost, port, "webclient-" + Math.random());
+        client.onConnectionLost = onConnectionLost;
+        client.onMessageArrived = onMessageArrived;
+        client.connect({ onSuccess: onConnect, onFailure: onFail, useSSL: location.protocol === 'https:' });
+    } else {
+        console.error('Paho MQTT library is not loaded');
+        statusEl.textContent = 'MQTT unavailable';
+        statusEl.className = 'text-sm text-red-600';
+    }
 
     const chart = Highcharts.chart('liveChart', {
         chart: { type: 'spline' },


### PR DESCRIPTION
## Summary
- Avoid runtime errors when Paho MQTT library is unavailable
- Document fallback behavior when Paho cannot be loaded

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1592dc280832ea591429a582c6044