### PR TITLE
Add realtime clouds/light/SQM chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,5 @@ Design decisions added after this file should be appended here for future refere
 
 21. The index page shows a bar chart of nightly observable hours for the last 30 days using safe data from `obs_weather`.
 
+22. Beneath the observable hours bar chart, the index page displays a live chart of clouds, light, and SQM values sourced from MQTT.
+


### PR DESCRIPTION
## Summary
- show live clouds, light, and SQM data in a new Highcharts spline chart below the observable-hours bar chart
- document new realtime chart in AGENTS guidelines

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c159d6b234832e81f6d8d8c7df2f23