### PR TITLE
Display large right-aligned MQTT values

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,13 +91,15 @@ const icons = {
     topicEntries.forEach(([name, topic]) => {
         const id = 'value-' + sanitize(name);
         const card = document.createElement('div');
-        card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow';
+        card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow h-48 flex flex-col';
         card.innerHTML = `
             <div class="flex items-center space-x-2">
                 <span class="text-2xl">${icons[name] || '📈'}</span>
                 <h2 class="text-xl font-semibold">${name}</h2>
             </div>
-            <p id="${id}" class="text-2xl mt-2">--</p>
+            <div class="flex-grow flex items-end justify-end" style="flex-basis:75%;">
+                <p id="${id}" class="text-right text-6xl leading-none">--</p>
+            </div>
             <div class="mt-2 flex space-x-2">
                 <a href="historical.php?topic=${encodeURIComponent(name)}" class="text-blue-500">History</a>
                 <button class="px-2 py-1 bg-blue-500 text-white rounded show-chart" data-topic="${topic}" data-name="${name}">Show</button>


### PR DESCRIPTION
## Summary
- Enlarge MQTT readings and align them to the right side of each Tailwind card
- Ensure value area fills most of the card height for clearer emphasis

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15a3f7ae0832eb97c675c828a3eb5