### PR TITLE
Handle missing Paho library using optional chaining

### DIFF
--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ const icons = {
         statusEl.className = 'text-sm text-red-600';
     }
 
-    if (typeof Paho !== 'undefined' && Paho.MQTT && Paho.MQTT.Client) {
+    if (window.Paho?.MQTT?.Client) {
         client = new Paho.MQTT.Client(brokerHost, port, "webclient-" + Math.random());
         client.onConnectionLost = onConnectionLost;
         client.onMessageArrived = onMessageArrived;


### PR DESCRIPTION
## Summary
- Use optional chaining to guard against missing Paho MQTT library
- Ensure page reports "MQTT unavailable" without runtime errors when Paho fails to load

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15ada917c832e8affac03c24b95c4