### PR TITLE
Add date range controls for historical data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,5 @@ Design decisions added after this file should be appended here for future refere
 
 22. Beneath the observable hours bar chart, the index page displays a live chart of clouds, light, and SQM values sourced from MQTT.
 
+23. Historical pages default to the last week of data and provide controls to view any date range in the database.
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views, shows a live updating graph, and displays nightly observable hours from the past 30 days
+- Historical pages default to the last week of readings and include date range controls to browse any period
 
 ## Sensor Data Tables
 

--- a/historical.php
+++ b/historical.php
@@ -26,10 +26,19 @@ $dbHost = getenv('DB_HOST');
 $dbName = getenv('DB_NAME');
 $dbUser = getenv('DB_USER');
 $dbPass = getenv('DB_PASS');
+
+// Determine requested date range; default to the last 7 days
+$start = $_GET['start'] ?? date('Y-m-d', strtotime('-1 week'));
+$end   = $_GET['end']   ?? date('Y-m-d');
+
+// Convert to timestamps compatible with the database
+$startDate = $start . ' 00:00:00';
+$endDate   = $end   . ' 23:59:59';
+
 try {
     $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
-    $stmt = $pdo->prepare("SELECT dateTime AS timestamp, `$column` AS value FROM obs_weather ORDER BY dateTime DESC LIMIT 100");
-    $stmt->execute();
+    $stmt = $pdo->prepare("SELECT dateTime AS timestamp, `$column` AS value FROM obs_weather WHERE dateTime BETWEEN :start AND :end ORDER BY dateTime ASC");
+    $stmt->execute(['start' => $startDate, 'end' => $endDate]);
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 } catch (Exception $e) {
     $rows = [];
@@ -52,6 +61,18 @@ try {
             <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
             <button id="modeToggle" class="px-2 py-1 border rounded">Toggle Mode</button>
         </div>
+        <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
+            <input type="hidden" name="topic" value="<?php echo htmlspecialchars($key); ?>">
+            <label class="flex flex-col">
+                <span>Start</span>
+                <input type="date" name="start" value="<?php echo htmlspecialchars($start); ?>" class="border rounded px-2 py-1">
+            </label>
+            <label class="flex flex-col">
+                <span>End</span>
+                <input type="date" name="end" value="<?php echo htmlspecialchars($end); ?>" class="border rounded px-2 py-1">
+            </label>
+            <button type="submit" class="px-2 py-1 border rounded">Apply</button>
+        </form>
         <div id="histChart" class="mb-6"></div>
         <div id="histTable"></div>
     </div>
@@ -62,7 +83,7 @@ try {
         document.documentElement.classList.toggle('dark');
     });
     const data = <?php echo json_encode($rows); ?>;
-    const chartData = data.map(r => [Date.parse(r.timestamp), parseFloat(r.value)]).reverse();
+    const chartData = data.map(r => [Date.parse(r.timestamp), parseFloat(r.value)]);
     Highcharts.chart('histChart', {
         chart: { type: 'line' },
         title: { text: 'Historical Data' },


### PR DESCRIPTION
## Summary
- show last week's data by default on historical page
- add start/end date form to query any range from the database
- document historical date range feature and record design decision

## Testing
- `php -l historical.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15b7b5fe0832e829c7e23879c5382