### PR TITLE
Improve MQTT connection reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,5 @@ Design decisions added after this file should be appended here for future refere
 
 23. Historical pages default to the last week of data and provide controls to view any date range in the database.
 
+24. The index page loads the Paho MQTT library with multiple fallbacks and automatically reconnects with exponential backoff if the MQTT connection is lost.
+


### PR DESCRIPTION
## Summary
- Dynamically load Paho MQTT library with CDN fallback
- Add automatic reconnection with exponential backoff for MQTT client
- Document MQTT fallback and reconnection behavior in AGENTS

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15cc022ac832e880ec73823a501bc