### PR TITLE
Enable dark mode styling for Highcharts charts

### DIFF
--- a/historical.php
+++ b/historical.php
@@ -59,7 +59,7 @@ try {
     <div class="container mx-auto p-4">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
-            <button id="modeToggle" class="px-2 py-1 border rounded">Toggle Mode</button>
+            <button id="modeToggle" class="px-2 py-1 border rounded">Switch to Dark Mode</button>
         </div>
         <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
             <input type="hidden" name="topic" value="<?php echo htmlspecialchars($key); ?>">
@@ -79,17 +79,40 @@ try {
 
     <script>
     const modeToggle = document.getElementById('modeToggle');
-    modeToggle.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-    });
     const data = <?php echo json_encode($rows); ?>;
     const chartData = data.map(r => [Date.parse(r.timestamp), parseFloat(r.value)]);
-    Highcharts.chart('histChart', {
+    const histChart = Highcharts.chart('histChart', {
         chart: { type: 'line' },
         title: { text: 'Historical Data' },
         xAxis: { type: 'datetime' },
         series: [{ name: <?php echo json_encode($key); ?>, data: chartData }]
     });
+
+    function updateChartTheme() {
+        const isDark = document.documentElement.classList.contains('dark');
+        const textColor = isDark ? '#F9FAFB' : '#1F2937';
+        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
+        const gridColor = isDark ? '#374151' : '#e5e7eb';
+        histChart.update({
+            chart: { backgroundColor: bgColor },
+            title: { style: { color: textColor } },
+            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor }
+        });
+    }
+
+    function updateModeText() {
+        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    }
+
+    modeToggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+        updateModeText();
+        updateChartTheme();
+    });
+
+    updateModeText();
+    updateChartTheme();
     new Tabulator('#histTable', {
         data: data,
         layout: 'fitColumns',

--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@ try {
             <h1 class="text-2xl font-bold">PubObs Live Data</h1>
             <div class="flex items-center space-x-2">
                 <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
-                <button id="modeToggle" class="px-2 py-1 border rounded">Toggle Mode</button>
+                <button id="modeToggle" class="px-2 py-1 border rounded">Switch to Dark Mode</button>
             </div>
         </div>
         <div id="cards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
@@ -182,7 +182,7 @@ const icons = {
 
     const safeCategories = safeData.map(r => r.day);
     const safeHours = safeData.map(r => parseFloat(r.hours));
-    Highcharts.chart('safeChart', {
+    const safeChart = Highcharts.chart('safeChart', {
         chart: { type: 'column' },
         title: { text: 'Observable Hours (Last 30 Days)' },
         xAxis: { categories: safeCategories },
@@ -202,9 +202,33 @@ const icons = {
     });
 
     const modeToggle = document.getElementById('modeToggle');
+
+    function updateChartsTheme() {
+        const isDark = document.documentElement.classList.contains('dark');
+        const textColor = isDark ? '#F9FAFB' : '#1F2937';
+        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
+        const gridColor = isDark ? '#374151' : '#e5e7eb';
+        [chart, safeChart, envChart].forEach(c => c.update({
+            chart: { backgroundColor: bgColor },
+            title: { style: { color: textColor } },
+            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+            legend: { itemStyle: { color: textColor } }
+        }, false));
+        [chart, safeChart, envChart].forEach(c => c.redraw());
+    }
+
+    function updateModeText() {
+        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    }
     modeToggle.addEventListener('click', () => {
         document.documentElement.classList.toggle('dark');
+        updateModeText();
+        updateChartsTheme();
     });
+
+    updateModeText();
+    updateChartsTheme();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Improve theme toggle button with clearer "Switch to Dark Mode" labeling and dynamic updates
- Apply light/dark theming to all Highcharts charts so they restyle when the theme is toggled

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15d00c8cc832ebf654efdf167ad7b