### PR TITLE
Add home navigation link to historical page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,4 @@ Design decisions added after this file should be appended here for future refere
 
 25. The index page loads the Paho MQTT library with multiple fallbacks and automatically reconnects with exponential backoff if the MQTT connection is lost.
 
+26. Historical pages provide a link back to the home page for easy navigation.

--- a/historical.php
+++ b/historical.php
@@ -58,6 +58,7 @@ try {
 </head>
 <body class="h-full bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div class="container mx-auto p-4">
+        <a href="index.php" class="mb-4 inline-block text-blue-600 dark:text-blue-400 underline">&larr; Back to Home</a>
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
             <button id="modeToggle" class="px-2 py-1 border rounded">Switch to Dark Mode</button>


### PR DESCRIPTION
## Summary
- Add a styled "Back to Home" link on historical pages for easier navigation
- Document new navigation link in AGENTS design decisions

## Testing
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15e86c610832ebbc4d73fd0a29aa0