### PR TITLE
Replace Paho client with MQTT.js via CDN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,17 @@ This file records design decisions and requirements for the PubObs website.
 Design decisions added after this file should be appended here for future reference.
 
 15. MQTT host and topic names are stored in `mqtt_config.json`.
-16. The website uses the Paho JavaScript client to subscribe to MQTT topics over WebSockets on port 8083.
+16. The website uses the MQTT.js JavaScript client to subscribe to MQTT topics over WebSockets on port 8083.
 17. Historical data resides in a MySQL table named `sensor_data` with columns `topic`, `timestamp`, and `value`.
 18. Database credentials are read from the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS`.
 19. Historical weather data is now stored in a MySQL table named `obs_weather` with columns `dateTime`, `clouds`, `temp`, `wind`, `gust`, `rain`, `light`, `switch`, `safe`, `hum`, and `dewp`.
 20. The index page displays current MQTT values in a responsive grid of Tailwind CSS cards.
 21. The index page shows an indicator reflecting the MQTT connection status.
 21. The index page shows a bar chart of nightly observable hours for the last 30 days using safe data from `obs_weather`.
-22. If the Paho MQTT library fails to load, the index page should display an MQTT unavailable status and avoid runtime errors.
+22. If the MQTT.js library fails to load, the index page should display an MQTT unavailable status and avoid runtime errors.
 22. Beneath the observable hours bar chart, the index page displays a live chart of clouds, light, and SQM values sourced from MQTT.
 23. Historical pages default to the last week of data and provide controls to view any date range in the database.
 24. The site uses `favicon.svg` as its favicon, linked from all pages.
-25. The index page loads the Paho MQTT library with multiple fallbacks and automatically reconnects with exponential backoff if the MQTT connection is lost.
+25. The index page loads the MQTT.js library with multiple fallbacks and automatically reconnects with exponential backoff if the MQTT connection is lost.
 26. Historical page queries are capped at a maximum span of seven days to prevent excessive data loads.
 


### PR DESCRIPTION
## Summary
- Replace Paho MQTT client with MQTT.js and connect via WebSockets
- Load MQTT.js from CDN with fallback and reconnect logic
- Update design docs to reflect switch to MQTT.js

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15f82bacc832ea5af7edcbd1a01ca