### PR TITLE
Replace historical table with CSV download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,4 +33,5 @@ Design decisions added after this file should be appended here for future refere
 24. The site uses `favicon.svg` as its favicon, linked from all pages.
 25. The index page loads the Paho MQTT library with multiple fallbacks and automatically reconnects with exponential backoff if the MQTT connection is lost.
 26. Historical page queries are capped at a maximum span of seven days to prevent excessive data loads.
+27. Historical pages provide a button to download data as CSV instead of displaying a table.
 

--- a/historical.php
+++ b/historical.php
@@ -63,8 +63,6 @@ try {
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
-    <link href="https://unpkg.com/tabulator-tables@5.4.4/dist/css/tabulator.min.css" rel="stylesheet">
-    <script src="https://unpkg.com/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>
 </head>
 <body class="h-full bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div class="container mx-auto p-4">
@@ -86,7 +84,7 @@ try {
             <button type="submit" class="px-2 py-1 border rounded">Apply</button>
         </form>
         <div id="histChart" class="mb-6"></div>
-        <div id="histTable"></div>
+        <button id="downloadCsv" class="px-2 py-1 border rounded">Download CSV</button>
     </div>
 
     <script>
@@ -125,13 +123,21 @@ try {
 
     updateModeText();
     updateChartTheme();
-    new Tabulator('#histTable', {
-        data: data,
-        layout: 'fitColumns',
-        columns: [
-            { title: 'Timestamp', field: 'timestamp' },
-            { title: 'Value', field: 'value' }
-        ]
+
+    document.getElementById('downloadCsv').addEventListener('click', () => {
+        const csvRows = ['timestamp,value'];
+        data.forEach(r => {
+            csvRows.push(`${r.timestamp},${r.value}`);
+        });
+        const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = <?php echo json_encode($key . '_history.csv'); ?>;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- remove Tabulator table from historical page and add a button to download the data as CSV
- document new CSV download in AGENTS design decisions

## Testing
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c161a2327c832e9c18b83b98589298