### PR TITLE
Enable dark mode styling on historical page

### DIFF
--- a/historical.php
+++ b/historical.php
@@ -62,6 +62,11 @@ try {
     <title>History: <?php echo htmlspecialchars($key); ?></title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+        }
+    </script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode in historical page

## Testing
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c164bc1ae4832eaefece233d963cd0