### PR TITLE
feat: add configurable card highlight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,5 @@ Design decisions added after this file should be appended here for future refere
 26. Historical page queries are capped at a maximum span of seven days to prevent excessive data loads.
 27. Historical pages provide a button to download data as CSV instead of displaying a table.
 
+28. `mqtt_config.json` topics can include a `green` threshold and `condition` (`above` or `below`) that turns the index page card border green when the incoming MQTT value meets the rule.
+

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ORDER BY dateTime DESC;
 ## Configuration
 
 MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
-The MQTT WebSocket port is 8083.
+Each topic can optionally include a `green` threshold and a `condition` of `above` or `below` to highlight the card border when the incoming value meets the rule. The MQTT WebSocket port is 8083.
 
 Database credentials are provided to Apache via environment variables:
 

--- a/index.php
+++ b/index.php
@@ -85,23 +85,25 @@ try {
 const brokerHost = (host === 'localhost' || host === '127.0.0.1') ? window.location.hostname : host;
 const topicEntries = Object.entries(topics);
 let selectedName = topicEntries.length ? topicEntries[0][0] : '';
-let selectedTopic = topicEntries.length ? topicEntries[0][1] : null;
+let selectedTopic = topicEntries.length ? topicEntries[0][1].topic : null;
 
 const envTopicNames = ['clouds', 'light', 'sqm'];
 const envSeriesMap = {};
 envTopicNames.forEach((name, idx) => {
-    if (topics[name]) envSeriesMap[topics[name]] = idx;
+    if (topics[name]) envSeriesMap[topics[name].topic] = idx;
 });
 
     const cardsContainer = document.getElementById('cards');
     cardsContainer.innerHTML = '';
     const sanitize = name => name.replace(/[^a-zA-Z0-9_-]/g, '_');
 
-    topicEntries.forEach(([name, topic]) => {
+    topicEntries.forEach(([name, cfg]) => {
+        const topic = cfg.topic;
         const id = 'value-' + sanitize(name);
         const card = document.createElement('div');
 
-        card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow h-32 flex';
+        card.id = 'card-' + sanitize(name);
+        card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow h-32 flex border-4 border-transparent';
         card.innerHTML = `
             <div class="flex flex-col justify-between w-1/2">
                 <h2 class="text-xl font-semibold">${name}</h2>
@@ -169,11 +171,25 @@ envTopicNames.forEach((name, idx) => {
     }
     function onMessageArrived(topic, message) {
         const value = parseFloat(message.toString());
-        const entry = topicEntries.find(([, t]) => t === topic);
+        const entry = topicEntries.find(([, cfg]) => cfg.topic === topic);
         if (entry) {
-            const id = 'value-' + sanitize(entry[0]);
+            const [name, cfg] = entry;
+            const id = 'value-' + sanitize(name);
             const el = document.getElementById(id);
             if (el) { el.textContent = value; }
+            const card = document.getElementById('card-' + sanitize(name));
+            if (card && cfg.green !== undefined && cfg.condition) {
+                let match = false;
+                if (cfg.condition === 'above') match = value > cfg.green;
+                else if (cfg.condition === 'below') match = value < cfg.green;
+                if (match) {
+                    card.classList.remove('border-transparent');
+                    card.classList.add('border-green-500');
+                } else {
+                    card.classList.remove('border-green-500');
+                    card.classList.add('border-transparent');
+                }
+            }
         }
         if (topic === selectedTopic) {
             const x = (new Date()).getTime();
@@ -188,7 +204,7 @@ envTopicNames.forEach((name, idx) => {
     function onConnect() {
         updateStatus('Connected', 'text-green-600');
         connectAttempts = 0;
-        Object.values(topics).forEach(t => client.subscribe(t));
+        Object.values(topics).forEach(cfg => client.subscribe(cfg.topic));
     }
 
     function loadMQTT(urls, idx = 0) {

--- a/mqtt_config.json
+++ b/mqtt_config.json
@@ -1,13 +1,14 @@
 {
   "host": "mqtt.smeird.com",
   "topics": {
-    "temperature": "Observatory/temp",
-    "rain": "Observatory/rain",
-    "light": "Observatory/light",
-    "clouds": "Observatory/clouds",
-    "safe": "Observatory/safe",
-    "sqm": "Observatory/sqm",
-    "humidity": "Observatory/hum",
-    "dewpoint": "Observatory/dewp"
+    "temperature": { "topic": "Observatory/temp" },
+    "rain": { "topic": "Observatory/rain" },
+    "light": { "topic": "Observatory/light", "green": 4000, "condition": "above" },
+    "clouds": { "topic": "Observatory/clouds" },
+    "safe": { "topic": "Observatory/safe" },
+    "sqm": { "topic": "Observatory/sqm" },
+    "humidity": { "topic": "Observatory/hum" },
+    "dewpoint": { "topic": "Observatory/dewp" }
   }
 }
+


### PR DESCRIPTION
## Summary
- allow topics in `mqtt_config.json` to include a green threshold and comparison
- highlight card borders when MQTT values meet configured condition
- document new configuration fields and design decision

## Testing
- `php -l index.php`
- `jq . mqtt_config.json`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c167210fb0832e8dfc7df4695da0f4