### PR TITLE
Rename site to Wheathampstead AstroPhotography Conditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,5 @@ Design decisions added after this file should be appended here for future refere
 26. Historical page queries are capped at a maximum span of seven days to prevent excessive data loads.
 27. Historical pages provide a button to download data as CSV instead of displaying a table.
 
+28. The site title is "Wheathampstead AstroPhotography Conditions".
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PubObs
+# Wheathampstead AstroPhotography Conditions
 
 Website that publicly shows observatory sensor data. The site displays live and historical sensor readings with a modern interface.
 

--- a/historical.php
+++ b/historical.php
@@ -59,7 +59,7 @@ try {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>History: <?php echo htmlspecialchars($key); ?></title>
+    <title>History: <?php echo htmlspecialchars($key); ?> - Wheathampstead AstroPhotography Conditions</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@ try {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PubObs Live Data</title>
+    <title>Wheathampstead AstroPhotography Conditions</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -54,7 +54,7 @@ try {
 <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
     <div class="max-w-6xl mx-auto p-6">
         <div class="flex justify-between items-center mb-8 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
-            <h1 class="text-2xl font-bold">PubObs Live Data</h1>
+            <h1 class="text-2xl font-bold">Wheathampstead AstroPhotography Conditions</h1>
             <div class="flex items-center space-x-2">
                 <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
                 <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>


### PR DESCRIPTION
## Summary
- Update index page title and header to "Wheathampstead AstroPhotography Conditions".
- Include site title in historical page titles for consistent branding.
- Document new site title in README and AGENTS design decisions.

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1677e92bc832e8baab1868ca6d32a