### PR TITLE
Add daisyUI theming and theme toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,7 @@ Design decisions added after this file should be appended here for future refere
 26. Historical page queries are capped at a maximum span of seven days to prevent excessive data loads.
 27. Historical pages provide a button to download data as CSV instead of displaying a table.
 
+28. The site uses the daisyUI plugin for Tailwind CSS theming with "dark", "light", and "dracula" themes.
+29. The "dark" theme is the default and system preferences switch automatically between "dark" and "light".
+30. A theme toggle lets users switch between "dark" and "dracula" modes at runtime, updating charts to maintain high-contrast colours.
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Historical data stored in a local MySQL table `obs_weather`
 - Highcharts for interactive graphs
 - Tabulator for data tables
-- Tailwind CSS default styling with light and dark modes
+- Tailwind CSS with daisyUI themes (dark, light, dracula) and a runtime toggle between dark and dracula
 - Index page lists all live data sources with links to historical views, shows a live updating graph, and displays nightly observable hours from the past 30 days
 - Historical pages default to the last week of readings and include date range controls to browse any period
 

--- a/historical.php
+++ b/historical.php
@@ -55,45 +55,55 @@ try {
 }
 ?>
 <!DOCTYPE html>
-<html class="h-full" lang="en">
+<html lang="en" data-theme="dark" class="h-full">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>History: <?php echo htmlspecialchars($key); ?></title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <script>
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', systemTheme);
+    </script>
+    <!-- Tailwind CSS with daisyUI -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/daisyui@4.6.0/dist/full.min.js"></script>
     <script>
         tailwind.config = {
-            darkMode: 'class',
+            plugins: [daisyui],
+            daisyui: {
+                themes: ["light", "dark", "dracula"],
+                darkTheme: "dark",
+            },
         }
     </script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
-    <div class="max-w-4xl mx-auto p-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-xl shadow-lg">
-        <a href="index.php" class="mb-4 inline-block text-indigo-600 dark:text-indigo-400 hover:underline">&larr; Back to Home</a>
-        <div class="flex justify-between items-center mb-6 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
+<body class="min-h-screen bg-base-200 text-base-content font-sans">
+    <div class="max-w-4xl mx-auto p-6 bg-base-100/80 backdrop-blur rounded-xl shadow-lg">
+        <a href="index.php" class="mb-4 inline-block text-primary hover:underline">&larr; Back to Home</a>
+        <div class="flex justify-between items-center mb-6 bg-base-100/70 backdrop-blur p-4 rounded-lg shadow">
             <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
-            <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+            <button id="themeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600">Switch to Dracula Theme</button>
         </div>
         <form method="get" class="mb-6 flex flex-wrap items-end gap-4">
             <input type="hidden" name="topic" value="<?php echo htmlspecialchars($key); ?>">
             <label class="flex flex-col">
                 <span>Start</span>
-                <input type="date" name="start" value="<?php echo htmlspecialchars($start); ?>" class="border rounded px-2 py-1 bg-white dark:bg-gray-700">
+                <input type="date" name="start" value="<?php echo htmlspecialchars($start); ?>" class="border rounded px-2 py-1 bg-base-100">
             </label>
             <label class="flex flex-col">
                 <span>End</span>
-                <input type="date" name="end" value="<?php echo htmlspecialchars($end); ?>" class="border rounded px-2 py-1 bg-white dark:bg-gray-700">
+                <input type="date" name="end" value="<?php echo htmlspecialchars($end); ?>" class="border rounded px-2 py-1 bg-base-100">
             </label>
-            <button type="submit" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Apply</button>
+            <button type="submit" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600">Apply</button>
         </form>
-        <div id="histChart" class="mb-6 bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow"></div>
-        <button id="downloadCsv" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Download CSV</button>
+        <div id="histChart" class="mb-6 bg-base-100/70 p-4 rounded-xl shadow"></div>
+        <button id="downloadCsv" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600">Download CSV</button>
     </div>
 
     <script>
-    const modeToggle = document.getElementById('modeToggle');
+    const themeToggle = document.getElementById('themeToggle');
     const data = <?php echo json_encode($rows); ?>;
     const chartData = data.map(r => [Date.parse(r.timestamp), parseFloat(r.value)]);
     const histChart = Highcharts.chart('histChart', {
@@ -103,30 +113,48 @@ try {
         series: [{ name: <?php echo json_encode($key); ?>, data: chartData }]
     });
 
+    const themeColors = {
+        light: { text: '#1F2937', bg: '#FFFFFF', grid: '#e5e7eb', series: ['#2563EB'] },
+        dark: { text: '#F9FAFB', bg: '#1f2937', grid: '#374151', series: ['#3b82f6'] },
+        dracula: { text: '#F8F8F2', bg: '#282A36', grid: '#44475a', series: ['#BD93F9'] }
+    };
+
     function updateChartTheme() {
-        const isDark = document.documentElement.classList.contains('dark');
-        const textColor = isDark ? '#F9FAFB' : '#1F2937';
-        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
-        const gridColor = isDark ? '#374151' : '#e5e7eb';
+        const theme = document.documentElement.getAttribute('data-theme') || 'dark';
+        const colors = themeColors[theme] || themeColors.dark;
         histChart.update({
-            chart: { backgroundColor: bgColor },
-            title: { style: { color: textColor } },
-            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor }
-        });
+            chart: { backgroundColor: colors.bg },
+            title: { style: { color: colors.text } },
+            xAxis: { labels: { style: { color: colors.text } }, gridLineColor: colors.grid, lineColor: colors.text },
+            yAxis: { labels: { style: { color: colors.text } }, title: { style: { color: colors.text } }, gridLineColor: colors.grid, lineColor: colors.text }
+        }, false);
+        histChart.series[0].update({ color: colors.series[0] }, false);
+        histChart.redraw();
     }
 
-    function updateModeText() {
-        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
-    }
-
-    modeToggle.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        updateModeText();
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        updateToggleText();
         updateChartTheme();
+    }
+
+    function updateToggleText() {
+        const current = document.documentElement.getAttribute('data-theme');
+        themeToggle.textContent = current === 'dracula' ? 'Switch to Dark Theme' : 'Switch to Dracula Theme';
+    }
+
+    themeToggle.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme');
+        if (current === 'light') {
+            setTheme('dark');
+        } else if (current === 'dark') {
+            setTheme('dracula');
+        } else {
+            setTheme('dark');
+        }
     });
 
-    updateModeText();
+    updateToggleText();
     updateChartTheme();
 
     document.getElementById('downloadCsv').addEventListener('click', () => {

--- a/index.php
+++ b/index.php
@@ -35,42 +35,51 @@ try {
 }
 ?>
 <!DOCTYPE html>
-<html class="h-full" lang="en">
+<html lang="en" data-theme="dark" class="h-full">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PubObs Live Data</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <!-- Tailwind CSS -->
+    <script>
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', systemTheme);
+    </script>
+    <!-- Tailwind CSS with daisyUI -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/daisyui@4.6.0/dist/full.min.js"></script>
     <script>
         tailwind.config = {
-            darkMode: 'class',
+            plugins: [daisyui],
+            daisyui: {
+                themes: ["light", "dark", "dracula"],
+                darkTheme: "dark",
+            },
         }
     </script>
     <!-- Highcharts -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
+<body class="min-h-screen bg-base-200 text-base-content font-sans">
     <div class="max-w-6xl mx-auto p-6">
-        <div class="flex justify-between items-center mb-8 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
+        <div class="flex justify-between items-center mb-8 bg-base-100/70 backdrop-blur p-4 rounded-lg shadow">
             <h1 class="text-2xl font-bold">PubObs Live Data</h1>
             <div class="flex items-center space-x-2">
-                <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
-                <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+                <span id="mqttStatus" class="text-sm text-warning">Connecting...</span>
+                <button id="themeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600">Switch to Dracula Theme</button>
             </div>
         </div>
         <div id="cards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
         <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div id="liveChartContainer" class="bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow flex flex-col">
+            <div id="liveChartContainer" class="bg-base-100/70 p-4 rounded-xl shadow flex flex-col">
                 <div id="liveChart" class="h-64"></div>
                 <button data-target="liveChartContainer" class="mt-2 px-2 py-1 bg-blue-500 text-white rounded fullscreen-btn">Full Screen</button>
             </div>
-            <div id="safeChartContainer" class="bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow flex flex-col">
+            <div id="safeChartContainer" class="bg-base-100/70 p-4 rounded-xl shadow flex flex-col">
                 <div id="safeChart" class="h-64"></div>
                 <button data-target="safeChartContainer" class="mt-2 px-2 py-1 bg-blue-500 text-white rounded fullscreen-btn">Full Screen</button>
             </div>
-            <div id="envChartContainer" class="bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow flex flex-col">
+            <div id="envChartContainer" class="bg-base-100/70 p-4 rounded-xl shadow flex flex-col">
                 <div id="envChart" class="h-64"></div>
                 <button data-target="envChartContainer" class="mt-2 px-2 py-1 bg-blue-500 text-white rounded fullscreen-btn">Full Screen</button>
             </div>
@@ -101,13 +110,13 @@ envTopicNames.forEach((name, idx) => {
         const id = 'value-' + sanitize(name);
         const card = document.createElement('div');
 
-        card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow h-32 flex';
+        card.className = 'bg-base-100 p-4 rounded shadow h-32 flex';
         card.innerHTML = `
             <div class="flex flex-col justify-between w-1/2">
                 <h2 class="text-xl font-semibold">${name}</h2>
 
                 <div class="mt-2 flex space-x-2">
-                    <a href="historical.php?topic=${encodeURIComponent(name)}" class="text-blue-500">History</a>
+                    <a href="historical.php?topic=${encodeURIComponent(name)}" class="text-primary">History</a>
                     <button class="px-2 py-1 bg-blue-500 text-white rounded show-chart" data-topic="${topic}" data-name="${name}">Show</button>
                 </div>
             </div>
@@ -139,7 +148,7 @@ envTopicNames.forEach((name, idx) => {
 
     function scheduleReconnect() {
         const delay = Math.min(1000 * Math.pow(2, connectAttempts), 30000);
-        updateStatus('Reconnecting...', 'text-yellow-600');
+        updateStatus('Reconnecting...', 'text-warning');
         setTimeout(() => {
             connectAttempts++;
             connectClient();
@@ -149,7 +158,7 @@ envTopicNames.forEach((name, idx) => {
     function connectClient() {
         if (!window.mqtt) {
             console.warn('MQTT.js library is not loaded');
-            updateStatus('MQTT unavailable', 'text-red-600');
+            updateStatus('MQTT unavailable', 'text-error');
             return;
         }
         const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -164,7 +173,7 @@ envTopicNames.forEach((name, idx) => {
 
     function onConnectionLost() {
         console.log('Connection lost');
-        updateStatus('Disconnected', 'text-red-600');
+        updateStatus('Disconnected', 'text-error');
         scheduleReconnect();
     }
     function onMessageArrived(topic, message) {
@@ -186,7 +195,7 @@ envTopicNames.forEach((name, idx) => {
         }
     }
     function onConnect() {
-        updateStatus('Connected', 'text-green-600');
+        updateStatus('Connected', 'text-success');
         connectAttempts = 0;
         Object.values(topics).forEach(t => client.subscribe(t));
     }
@@ -194,7 +203,7 @@ envTopicNames.forEach((name, idx) => {
     function loadMQTT(urls, idx = 0) {
         if (idx >= urls.length) {
             console.warn('MQTT.js library failed to load');
-            updateStatus('MQTT unavailable', 'text-red-600');
+            updateStatus('MQTT unavailable', 'text-error');
             return;
         }
         const script = document.createElement('script');
@@ -255,33 +264,53 @@ envTopicNames.forEach((name, idx) => {
         });
     });
 
-    const modeToggle = document.getElementById('modeToggle');
+    const themeToggle = document.getElementById('themeToggle');
+
+    const themeColors = {
+        light: { text: '#1F2937', bg: '#FFFFFF', grid: '#e5e7eb', series: ['#2563EB', '#047857', '#DC2626'] },
+        dark: { text: '#F9FAFB', bg: '#1f2937', grid: '#374151', series: ['#3b82f6', '#10b981', '#ef4444'] },
+        dracula: { text: '#F8F8F2', bg: '#282A36', grid: '#44475a', series: ['#BD93F9', '#50FA7B', '#FF5555'] }
+    };
 
     function updateChartsTheme() {
-        const isDark = document.documentElement.classList.contains('dark');
-        const textColor = isDark ? '#F9FAFB' : '#1F2937';
-        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
-        const gridColor = isDark ? '#374151' : '#e5e7eb';
-        [chart, safeChart, envChart].forEach(c => c.update({
-            chart: { backgroundColor: bgColor },
-            title: { style: { color: textColor } },
-            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            legend: { itemStyle: { color: textColor } }
-        }, false));
-        [chart, safeChart, envChart].forEach(c => c.redraw());
+        const theme = document.documentElement.getAttribute('data-theme') || 'dark';
+        const colors = themeColors[theme] || themeColors.dark;
+        [chart, safeChart, envChart].forEach(c => {
+            c.update({
+                chart: { backgroundColor: colors.bg },
+                title: { style: { color: colors.text } },
+                xAxis: { labels: { style: { color: colors.text } }, gridLineColor: colors.grid, lineColor: colors.text },
+                yAxis: { labels: { style: { color: colors.text } }, title: { style: { color: colors.text } }, gridLineColor: colors.grid, lineColor: colors.text },
+                legend: { itemStyle: { color: colors.text } }
+            }, false);
+            c.series.forEach((s, i) => s.update({ color: colors.series[i % colors.series.length] }, false));
+            c.redraw();
+        });
     }
 
-    function updateModeText() {
-        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
-    }
-    modeToggle.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        updateModeText();
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        updateToggleText();
         updateChartsTheme();
+    }
+
+    function updateToggleText() {
+        const current = document.documentElement.getAttribute('data-theme');
+        themeToggle.textContent = current === 'dracula' ? 'Switch to Dark Theme' : 'Switch to Dracula Theme';
+    }
+
+    themeToggle.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme');
+        if (current === 'light') {
+            setTheme('dark');
+        } else if (current === 'dark') {
+            setTheme('dracula');
+        } else {
+            setTheme('dark');
+        }
     });
 
-    updateModeText();
+    updateToggleText();
     updateChartsTheme();
     </script>
 </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: ["./**/*.php"],
+  theme: {
+    extend: {},
+  },
+  plugins: [require("daisyui")],
+  daisyui: {
+    themes: ["dark", "light", "dracula"],
+    darkTheme: "dark",
+  },
+};


### PR DESCRIPTION
## Summary
- integrate TailwindCSS with daisyUI and enable light, dark and dracula themes
- auto-select dark or light based on system preference and add toggle for dark/dracula
- update charts and docs for high contrast across themes

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c168a2a630832ea93317616ae79aff