### PR TITLE
Fix observable hours graph to sum safe durations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,4 @@ Design decisions added after this file should be appended here for future refere
 27. Historical pages provide a button to download data as CSV instead of displaying a table.
 28. The site title is "Wheathampstead AstroPhotography Conditions".
 29. `mqtt_config.json` topics can include a `green` threshold and `condition` (`above` or `below`) that turns the index page card border green when the incoming MQTT value meets the rule.
+30. Observable hours are calculated by summing time intervals where the `safe` field equals 1.


### PR DESCRIPTION
## Summary
- Calculate daily observable hours by summing intervals where `safe` equals 1
- Document the observable-hours calculation approach

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16c6eed7c832e9f32fb28d076f901