### PR TITLE
Add unit configuration for MQTT topics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,4 @@ Design decisions added after this file should be appended here for future refere
 27. Historical pages provide a button to download data as CSV instead of displaying a table.
 28. The site title is "Wheathampstead AstroPhotography Conditions".
 29. `mqtt_config.json` topics can include a `green` threshold and `condition` (`above` or `below`) that turns the index page card border green when the incoming MQTT value meets the rule.
+30. `mqtt_config.json` topics may define a `unit` string to specify the measurement unit for display.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ORDER BY dateTime DESC;
 ## Configuration
 
 MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
-Each topic can optionally include a `green` threshold and a `condition` of `above` or `below` to highlight the card border when the incoming value meets the rule. The MQTT WebSocket port is 8083.
+Each topic can optionally include a `green` threshold and a `condition` of `above` or `below` to highlight the card border when the incoming value meets the rule. Topics may also specify a `unit` string to label displayed values. The MQTT WebSocket port is 8083.
 
 Database credentials are provided to Apache via environment variables:
 

--- a/mqtt_config.json
+++ b/mqtt_config.json
@@ -1,14 +1,14 @@
 {
   "host": "mqtt.smeird.com",
   "topics": {
-    "temperature": { "topic": "Observatory/temp" },
-    "rain": { "topic": "Observatory/rain" },
-    "light": { "topic": "Observatory/light", "green": 4000, "condition": "above" },
-    "clouds": { "topic": "Observatory/clouds" },
-    "safe": { "topic": "Observatory/safe" },
-    "sqm": { "topic": "Observatory/sqm" },
-    "humidity": { "topic": "Observatory/hum" },
-    "dewpoint": { "topic": "Observatory/dewp" }
+    "temperature": { "topic": "Observatory/temp", "unit": "°C" },
+    "rain": { "topic": "Observatory/rain", "unit": "mm" },
+    "light": { "topic": "Observatory/light", "green": 4000, "condition": "above", "unit": "lux" },
+    "clouds": { "topic": "Observatory/clouds", "unit": "%" },
+    "safe": { "topic": "Observatory/safe", "unit": "bool" },
+    "sqm": { "topic": "Observatory/sqm", "unit": "mag/arcsec^2" },
+    "humidity": { "topic": "Observatory/hum", "unit": "%" },
+    "dewpoint": { "topic": "Observatory/dewp", "unit": "°C" }
   }
 }
 


### PR DESCRIPTION
## Summary
- add unit fields for each MQTT topic
- document optional unit property in configuration
- record unit configuration design decision

## Testing
- `jq . mqtt_config.json`
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16cdf9dcc832ea35b67b2a719a6b3