### PR TITLE
Stream safe data aggregation to avoid memory exhaustion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,4 +39,5 @@ Design decisions added after this file should be appended here for future refere
 30. `mqtt_config.json` topics may define a `unit` string to specify the measurement unit for display.
 31. The index page displays an icon before each MQTT topic name in its card.
 32. Observable hours are calculated by summing time intervals where the `safe` field equals 1.
+33. Safe data aggregation processes database rows sequentially to limit memory usage.
 


### PR DESCRIPTION
## Summary
- Avoid fetching entire `obs_weather` result set at once to prevent PHP out-of-memory errors.
- Document sequential processing of safe data in AGENTS guidelines.

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16f36481c832ea2d49cd10ff557f1