### PR TITLE
Add monthly clear-sky statistics page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,4 @@ Design decisions added after this file should be appended here for future refere
 32. Observable hours are calculated by summing time intervals where the `safe` field equals 1.
 33. Safe data aggregation processes database rows sequentially to limit memory usage.
 
+34. The site includes a `clear.php` page that charts monthly safe observing hours for a selected year and is linked from the index page.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views, shows a live updating graph, and displays nightly observable hours from the past 30 days
 - Historical pages default to the last week of readings and include date range controls to browse any period
+- Clear page shows safe observing hours aggregated by month for a selected year
 
 ## Sensor Data Tables
 
@@ -72,6 +73,7 @@ SetEnv DB_PASS "secret"
 ```mermaid
 flowchart LR
     Index["index.php"] --> Hist["historical.php"]
+    Index --> Clear["clear.php"]
 ```
 
 ## Architecture

--- a/clear.php
+++ b/clear.php
@@ -1,0 +1,116 @@
+<?php
+$yearParam = $_GET['year'] ?? date('Y');
+$year = (int)$yearParam;
+
+$dbHost = getenv('DB_HOST');
+$dbName = getenv('DB_NAME');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+
+$monthSeconds = array_fill(1, 12, 0);
+$years = [];
+try {
+    $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $years = $pdo->query("SELECT DISTINCT YEAR(FROM_UNIXTIME(dateTime)) AS y FROM obs_weather ORDER BY y DESC")->fetchAll(PDO::FETCH_COLUMN);
+    $start = $year . '-01-01 00:00:00';
+    $end = ($year + 1) . '-01-01 00:00:00';
+    $stmt = $pdo->prepare("SELECT dateTime, safe FROM obs_weather WHERE dateTime BETWEEN UNIX_TIMESTAMP(:start) AND UNIX_TIMESTAMP(:end) ORDER BY dateTime");
+    $stmt->execute(['start' => $start, 'end' => $end]);
+    $prev = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($prev) {
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $currTime = (int)$prev['dateTime'];
+            $nextTime = (int)$row['dateTime'];
+            if ((int)$prev['safe'] === 1) {
+                $segmentStart = $currTime;
+                $segmentEnd = $nextTime;
+                while ($segmentStart < $segmentEnd) {
+                    $month = (int)date('n', $segmentStart);
+                    $monthStart = strtotime(date('Y-m-01', $segmentStart));
+                    $nextMonthStart = strtotime('+1 month', $monthStart);
+                    $boundary = min($segmentEnd, $nextMonthStart);
+                    $monthSeconds[$month] += $boundary - $segmentStart;
+                    $segmentStart = $boundary;
+                }
+            }
+            $prev = $row;
+        }
+    }
+} catch (Exception $e) {
+    $monthSeconds = array_fill(1, 12, 0);
+}
+$monthHours = array_map(function ($s) { return round($s / 3600, 2); }, $monthSeconds);
+$monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+?>
+<!DOCTYPE html>
+<html class="h-full" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clear Observing by Month - Wheathampstead AstroPhotography Conditions</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+        }
+    </script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+</head>
+<body class="min-h-screen bg-gradient-to-br from-indigo-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
+    <div class="max-w-4xl mx-auto p-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-xl shadow-lg">
+        <a href="index.php" class="mb-4 inline-block text-indigo-600 dark:text-indigo-400 hover:underline">&larr; Back to Home</a>
+        <div class="flex justify-between items-center mb-6 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
+            <h1 class="text-2xl font-bold">Clear Nights by Month</h1>
+            <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+        </div>
+        <form method="get" class="mb-6 flex items-end gap-4">
+            <label class="flex flex-col">
+                <span>Year</span>
+                <select name="year" class="border rounded px-2 py-1 bg-white dark:bg-gray-700">
+                    <?php foreach ($years as $y): ?>
+                    <option value="<?= htmlspecialchars($y) ?>" <?= $y == $year ? 'selected' : '' ?>><?= htmlspecialchars($y) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <button type="submit" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Apply</button>
+        </form>
+        <div id="monthChart" class="bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow"></div>
+    </div>
+    <script>
+    const monthNames = <?php echo json_encode($monthNames); ?>;
+    const monthData = <?php echo json_encode(array_values($monthHours)); ?>;
+    const chart = Highcharts.chart('monthChart', {
+        chart: { type: 'column' },
+        title: { text: 'Safe Observing Hours in ' + <?php echo json_encode($year); ?> },
+        xAxis: { categories: monthNames },
+        yAxis: { title: { text: 'Hours' } },
+        series: [{ name: 'Hours', data: monthData }]
+    });
+    const modeToggle = document.getElementById('modeToggle');
+    function updateChartTheme() {
+        const isDark = document.documentElement.classList.contains('dark');
+        const textColor = isDark ? '#F9FAFB' : '#1F2937';
+        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
+        const gridColor = isDark ? '#374151' : '#e5e7eb';
+        chart.update({
+            chart: { backgroundColor: bgColor },
+            title: { style: { color: textColor } },
+            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+            legend: { itemStyle: { color: textColor } }
+        });
+    }
+    function updateModeText() {
+        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    }
+    modeToggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+        updateModeText();
+        updateChartTheme();
+    });
+    updateModeText();
+    updateChartTheme();
+    </script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -81,6 +81,7 @@ try {
             </h1>
             <div class="flex items-center space-x-2">
                 <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
+                <a href="clear.php" class="text-indigo-600 dark:text-indigo-400 hover:underline">Clear by Month</a>
                 <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add `clear.php` page that charts safe observing hours by month for a chosen year
- link new clear-sky page from the index
- document new page in README and AGENTS design notes

## Testing
- `php -l index.php`
- `php -l clear.php`


------
https://chatgpt.com/codex/tasks/task_e_68c171d43230832e9e44f5a8d2905e90