### PR TITLE
Condense title and switch to icon dark-mode toggle

### DIFF
--- a/historical.php
+++ b/historical.php
@@ -74,7 +74,7 @@ try {
         <a href="index.php" class="mb-4 inline-block text-indigo-600 dark:text-indigo-400 hover:underline">&larr; Back to Home</a>
         <div class="flex justify-between items-center mb-6 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
             <h1 class="text-2xl font-bold">History: <?php echo htmlspecialchars($key); ?></h1>
-            <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+            <button id="modeToggle" class="p-2 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700" aria-label="Switch to Dark Mode">🌙</button>
         </div>
         <form method="get" class="mb-6 flex flex-wrap items-end gap-4">
             <input type="hidden" name="topic" value="<?php echo htmlspecialchars($key); ?>">
@@ -116,17 +116,19 @@ try {
         });
     }
 
-    function updateModeText() {
-        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    function updateModeIcon() {
+        const isDark = document.documentElement.classList.contains('dark');
+        modeToggle.textContent = isDark ? '🌞' : '🌙';
+        modeToggle.setAttribute('aria-label', isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode');
     }
 
     modeToggle.addEventListener('click', () => {
         document.documentElement.classList.toggle('dark');
-        updateModeText();
+        updateModeIcon();
         updateChartTheme();
     });
 
-    updateModeText();
+    updateModeIcon();
     updateChartTheme();
 
     document.getElementById('downloadCsv').addEventListener('click', () => {

--- a/index.php
+++ b/index.php
@@ -77,11 +77,12 @@ try {
         <div class="flex justify-between items-center mb-8 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
             <h1 class="flex items-center text-2xl font-bold">
                 <img src="favicon.svg" alt="" class="w-8 h-8 mr-2">
-                Wheathampstead AstroPhotography Conditions
+                <span class="hidden sm:inline">Wheathampstead AstroPhotography Conditions</span>
+                <span class="sm:hidden">WAPC</span>
             </h1>
             <div class="flex items-center space-x-2">
                 <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
-                <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+                <button id="modeToggle" class="p-2 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700" aria-label="Switch to Dark Mode">🌙</button>
             </div>
         </div>
         <div id="cards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
@@ -325,16 +326,19 @@ envTopicNames.forEach((name, idx) => {
         [chart, safeChart, envChart].forEach(c => c.redraw());
     }
 
-    function updateModeText() {
-        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
+    function updateModeIcon() {
+        const isDark = document.documentElement.classList.contains('dark');
+        modeToggle.textContent = isDark ? '🌞' : '🌙';
+        modeToggle.setAttribute('aria-label', isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode');
     }
+
     modeToggle.addEventListener('click', () => {
         document.documentElement.classList.toggle('dark');
-        updateModeText();
+        updateModeIcon();
         updateChartsTheme();
     });
 
-    updateModeText();
+    updateModeIcon();
     updateChartsTheme();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Abbreviate the site title to initials on small screens
- Replace dark mode text buttons with sun/moon icons and responsive labels

## Testing
- `php -l index.php`
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1722172ac832e9b72a4746ba5b1d3