### PR TITLE
Use icons for history and show buttons

### DIFF
--- a/index.php
+++ b/index.php
@@ -175,8 +175,18 @@ const envSeries = envTopicNames.map(name => {
                 <h2 class="text-xl font-semibold flex items-center"><span class="mr-2">${icon}</span>${name}</h2>
 
                 <div class="mt-2 flex space-x-2">
-                    <a href="historical.php?topic=${encodeURIComponent(name)}" class="text-indigo-600 dark:text-indigo-400 hover:underline">History</a>
-                    <button class="px-2 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700 show-chart" data-topic="${topic}" data-name="${name}">Show</button>
+                    <a href="historical.php?topic=${encodeURIComponent(name)}" class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300" aria-label="View History">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <circle cx="12" cy="12" r="9" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7v5l3 1.5" />
+                        </svg>
+                    </a>
+                    <button class="p-2 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700 show-chart" data-topic="${topic}" data-name="${name}" aria-label="Show Live Chart">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12c1.607-4.205 5.64-7.25 9.75-7.25s8.143 3.045 9.75 7.25c-1.607 4.205-5.64 7.25-9.75 7.25S3.857 16.205 2.25 12z" />
+                            <circle cx="12" cy="12" r="3" />
+                        </svg>
+                    </button>
                 </div>
             </div>
             <div class="w-1/2 flex items-center justify-center">
@@ -188,9 +198,10 @@ const envSeries = envTopicNames.map(name => {
     });
 
     document.addEventListener('click', e => {
-        if (e.target.classList.contains('show-chart')) {
-            selectedTopic = e.target.dataset.topic;
-            selectedName = e.target.dataset.name;
+        const btn = e.target.closest('.show-chart');
+        if (btn) {
+            selectedTopic = btn.dataset.topic;
+            selectedName = btn.dataset.name;
             selectedUnit = topics[selectedName] && topics[selectedName].unit ? topics[selectedName].unit : '';
             chart.series[0].setData([]);
             chart.setTitle({ text: 'Live Sensor Data: ' + selectedName + (selectedUnit ? ' (' + selectedUnit + ')' : '') });


### PR DESCRIPTION
## Summary
- Replace History link and Show button text with inline icons and aria labels for cleaner card controls
- Update click handler to work when icons are nested in the button

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_68c19921cbd4832e84256a1303d7aabe