### PR TITLE
Replace live sensor graph with MQTT sky image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,5 @@ Design decisions added after this file should be appended here for future refere
 34. The site includes a `clear.php` page that charts monthly safe observing hours for a selected year and is linked from the index page.
 
 35. Safe-hour charts include time from the last record to the current period end to account for ongoing clear conditions.
+
+36. The index page displays a sky image updated via the MQTT topic `Observatory/skyimage` instead of a live sensor graph.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Highcharts for interactive graphs
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
-- Index page lists all live data sources with links to historical views, shows a live updating graph, and displays nightly observable hours from the past 30 days
+- Index page lists all live data sources with links to historical views, shows a live sky image sourced via MQTT, and displays nightly observable hours from the past 30 days
 - Historical pages default to the last week of readings and include date range controls to browse any period
 - Clear page shows safe observing hours aggregated by month for a selected year
 


### PR DESCRIPTION
## Summary
- Replace live sensor data chart with a sky image panel fed by MQTT topic `Observatory/skyimage`.
- Subscribe to `Observatory/skyimage` and update image when messages arrive.
- Remove live chart selection UI and document the new design in README and AGENTS.

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c28b8e23c0832ea8d61b07be8ee600