### PR TITLE
Use Highcharts range selector for historical charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,5 @@ Design decisions added after this file should be appended here for future refere
 35. Safe-hour charts include time from the last record to the current period end to account for ongoing clear conditions.
 
 36. The index page displays a sky image updated via the MQTT topic `Observatory/skyimage` instead of a live sensor graph.
+
+37. Historical charts use Highcharts' range selector to manage date ranges instead of manual date inputs.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views, shows a live sky image sourced via MQTT, and displays nightly observable hours from the past 30 days
-- Historical pages default to the last week of readings and include date range controls to browse any period
+- Historical pages default to the last week of readings and use Highcharts controls to browse any period
 - Clear page shows safe observing hours aggregated by month for a selected year
 
 ## Sensor Data Tables


### PR DESCRIPTION
## Summary
- Replace manual date inputs with Highcharts range selector that fetches data for selected range
- Add JSON response mode to `historical.php` to support dynamic updates
- Document Highcharts-managed date ranges in README and AGENTS

## Testing
- `php -l historical.php`


------
https://chatgpt.com/codex/tasks/task_e_68c294e255f4832e97a3bc4d10dd28b5