### PR TITLE
Enable open-ended filters for historical data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ Design decisions added after this file should be appended here for future refere
 37. Historical charts use Highcharts' range selector to manage date ranges instead of manual date inputs.
 
 38. Historical pages load all available data by default, removing the previous seven-day query limit.
+39. Historical queries accept optional `start` or `end` parameters to filter results without requiring both.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Website that publicly shows observatory sensor data. The site displays live and 
 - Tabulator for data tables
 - Tailwind CSS default styling with light and dark modes
 - Index page lists all live data sources with links to historical views, shows a live sky image sourced via MQTT, and displays nightly observable hours from the past 30 days
-- Historical pages default to the last week of readings and use Highcharts controls to browse any period
+- Historical pages load all available readings by default and use Highcharts controls to browse any range
+- Historical pages accept optional `start` and `end` query parameters (`YYYY-MM-DD`) to limit the data returned
 - Clear page shows safe observing hours aggregated by month for a selected year
 
 ## Sensor Data Tables


### PR DESCRIPTION
## Summary
- Allow historical queries to filter with optional `start` or `end` dates or return full dataset when unspecified
- Document that historical pages load all data by default and support `start`/`end` query parameters
- Record new design decision for open-ended historical filters

## Testing
- `php -l historical.php`
- `php -l index.php`
- `php -l clear.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6b17454ec832ea30532381dc8022c