### PR TITLE
Add persistent accent font weight configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,5 @@ Design decisions added after this file should be appended here for future refere
 39. Historical queries accept optional `start` or `end` parameters to filter results without requiring both.
 40. Historical pages fetch data asynchronously via a JSON endpoint to handle large result sets without exhausting server memory.
 
+41. Accent font weight preferences are stored in the MySQL `site_settings` table and controlled via the index page header.
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Website that publicly shows observatory sensor data. The site displays live and 
 
 - Historical pages accept optional `start` and `end` query parameters (`YYYY-MM-DD`) to limit the data returned
 - Clear page shows safe observing hours aggregated by month for a selected year
+- Accent font weight can be adjusted from the index page header; the preference is stored in MySQL for consistent styling
 
 ## Sensor Data Tables
 
@@ -53,6 +54,8 @@ ORDER BY dateTime DESC;
 
 MQTT host and topic names are defined in `mqtt_config.json`. Update this file to match your local MQTT broker settings.
 Each topic can optionally include a `green` threshold and a `condition` of `above` or `below` to highlight the card border when the incoming value meets the rule. Topics may also specify a `unit` string to label displayed values. The MQTT WebSocket port is 8083.
+
+Accent typography uses the `site_settings` MySQL table. The `settings.php` endpoint stores the `accent_font_weight` value selected from the index page, and pages read the value to apply consistent styling.
 
 Database credentials are provided to Apache via environment variables:
 

--- a/index.php
+++ b/index.php
@@ -3,6 +3,8 @@ $config = json_decode(file_get_contents('mqtt_config.json'), true);
 $host = $config['host'] ?? 'localhost';
 $topics = $config['topics'] ?? [];
 
+$accentFontWeight = '600';
+
 $dbHost = getenv('DB_HOST');
 $dbName = getenv('DB_NAME');
 $dbUser = getenv('DB_USER');
@@ -11,6 +13,14 @@ $dbPass = getenv('DB_PASS');
 $safeData = [];
 try {
     $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS site_settings (name VARCHAR(191) PRIMARY KEY, value TEXT NOT NULL)");
+    $settingStmt = $pdo->prepare("SELECT value FROM site_settings WHERE name = :name");
+    $settingStmt->execute(['name' => 'accent_font_weight']);
+    $setting = $settingStmt->fetchColumn();
+    if (is_string($setting) && preg_match('/^(100|200|300|400|500|600|700|800|900)$/', $setting)) {
+        $accentFontWeight = $setting;
+    }
 
     // Build map for last 30 days initialised to 0 hours
     $start = new DateTime('today -29 days');
@@ -54,6 +64,7 @@ try {
     }
 } catch (Exception $e) {
     $safeData = [];
+    $accentFontWeight = '600';
 }
 ?>
 <!DOCTYPE html>
@@ -72,6 +83,15 @@ try {
     </script>
     <!-- Highcharts -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <style>
+        :root {
+            --accent-font-weight: <?= htmlspecialchars($accentFontWeight, ENT_QUOTES) ?>;
+        }
+        .accent-value,
+        .accent-unit {
+            font-weight: var(--accent-font-weight, 600);
+        }
+    </style>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-indigo-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
     <div class="max-w-6xl mx-auto p-6">
@@ -81,10 +101,22 @@ try {
                 <span class="hidden sm:inline">Wheathampstead AstroPhotography Conditions</span>
                 <span class="sm:hidden">WAPC</span>
             </h1>
-            <div class="flex items-center space-x-2">
+            <div class="flex items-center space-x-3">
                 <span id="mqttStatus" class="text-sm text-yellow-600">Connecting...</span>
 
                 <a href="clear.php" class="text-indigo-600 dark:text-indigo-400 hover:underline">Clear by Month</a>
+
+                <div class="flex flex-col items-start">
+                    <div class="flex items-center space-x-1">
+                        <label for="accentWeightSelect" class="text-sm text-gray-700 dark:text-gray-300 hidden sm:block">Accent Weight</label>
+                        <select id="accentWeightSelect" aria-label="Accent font weight" class="border border-indigo-200 dark:border-gray-700 rounded px-2 py-1 bg-white/80 dark:bg-gray-700/80 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <?php foreach ([100,200,300,400,500,600,700,800,900] as $weightOption): ?>
+                            <option value="<?= $weightOption ?>" <?= $weightOption === (int)$accentFontWeight ? 'selected' : '' ?>><?= $weightOption ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <span id="accentSaveStatus" class="text-xs hidden"></span>
+                </div>
 
                 <button id="modeToggle" class="p-2 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700" aria-label="Switch to Dark Mode">🌙</button>
 
@@ -111,6 +143,7 @@ try {
     const topics = <?php echo json_encode($topics); ?>;
     const host = <?php echo json_encode($host); ?>;
     const safeData = <?php echo json_encode($safeData); ?>;
+    let currentAccentFontWeight = <?php echo json_encode($accentFontWeight); ?>;
     const port = 8083; // default WebSocket port for MQTT
 const brokerHost = (host === 'localhost' || host === '127.0.0.1') ? window.location.hostname : host;
 const topicEntries = Object.entries(topics);
@@ -150,7 +183,7 @@ const envSeries = envTopicNames.map(name => {
         card.id = 'card-' + sanitize(name);
         card.className = 'bg-gray-100 dark:bg-gray-800 p-4 rounded shadow h-32 flex border-4 border-transparent';
         const icon = icons[name] || '📟';
-        const unitMarkup = cfg.unit ? `<span class="text-2xl ml-1">${cfg.unit}</span>` : '';
+        const unitMarkup = cfg.unit ? `<span class="text-2xl ml-1 accent-unit">${cfg.unit}</span>` : '';
         card.innerHTML = `
             <div class="flex flex-col justify-between w-1/2">
                 <h2 class="text-xl font-semibold flex items-center"><span class="mr-2">${icon}</span>${name}</h2>
@@ -164,7 +197,7 @@ const envSeries = envTopicNames.map(name => {
                 </div>
             </div>
             <div class="w-1/2 flex items-center justify-center">
-                <p class="text-right text-6xl leading-none flex items-baseline justify-end"><span id="${id}">--</span>${unitMarkup}</p>
+                <p class="text-right text-6xl leading-none flex items-baseline justify-end"><span id="${id}" class="accent-value">--</span>${unitMarkup}</p>
             </div>
 
         `;
@@ -289,6 +322,75 @@ const envSeries = envTopicNames.map(name => {
         xAxis: { type: 'datetime' },
         series: envSeries
     });
+
+    const accentWeightSelect = document.getElementById('accentWeightSelect');
+    const accentSaveStatus = document.getElementById('accentSaveStatus');
+
+    function applyAccentFontWeight(weight) {
+        currentAccentFontWeight = weight;
+        document.documentElement.style.setProperty('--accent-font-weight', weight);
+    }
+
+    function displayAccentStatus(message, variant = 'info') {
+        if (!accentSaveStatus) return;
+        accentSaveStatus.textContent = message;
+        accentSaveStatus.classList.remove('hidden', 'text-gray-500', 'dark:text-gray-300', 'text-green-600', 'dark:text-green-400', 'text-red-500', 'dark:text-red-400');
+        const classes = variant === 'success'
+            ? ['text-green-600', 'dark:text-green-400']
+            : variant === 'error'
+                ? ['text-red-500', 'dark:text-red-400']
+                : ['text-gray-500', 'dark:text-gray-300'];
+        accentSaveStatus.classList.add(...classes);
+        if (displayAccentStatus.timeout) {
+            clearTimeout(displayAccentStatus.timeout);
+            displayAccentStatus.timeout = null;
+        }
+        if (variant !== 'info') {
+            displayAccentStatus.timeout = setTimeout(() => {
+                accentSaveStatus.classList.add('hidden');
+                displayAccentStatus.timeout = null;
+            }, 2500);
+        }
+    }
+
+    displayAccentStatus.timeout = null;
+
+    applyAccentFontWeight(currentAccentFontWeight);
+
+    if (accentWeightSelect) {
+        accentWeightSelect.value = currentAccentFontWeight;
+        accentWeightSelect.addEventListener('change', () => {
+            const newWeight = accentWeightSelect.value;
+            const previousWeight = currentAccentFontWeight;
+            applyAccentFontWeight(newWeight);
+            displayAccentStatus('Saving...', 'info');
+            fetch('settings.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ accent_font_weight: newWeight })
+            })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Request failed');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (!data.success) {
+                        throw new Error('Save failed');
+                    }
+                    currentAccentFontWeight = newWeight;
+                    displayAccentStatus('Saved', 'success');
+                })
+                .catch(error => {
+                    console.error('Failed to update accent font weight', error);
+                    applyAccentFontWeight(previousWeight);
+                    currentAccentFontWeight = previousWeight;
+                    accentWeightSelect.value = previousWeight;
+                    displayAccentStatus('Save failed', 'error');
+                });
+        });
+    }
 
     document.querySelectorAll('.fullscreen-btn').forEach(btn => {
         btn.addEventListener('click', () => {

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,57 @@
+<?php
+header('Content-Type: application/json');
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$dbHost = getenv('DB_HOST');
+$dbName = getenv('DB_NAME');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+
+try {
+    $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $pdo->exec("CREATE TABLE IF NOT EXISTS site_settings (name VARCHAR(191) PRIMARY KEY, value TEXT NOT NULL)");
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Unable to connect to the database']);
+    exit;
+}
+
+function sanitize_weight($weight)
+{
+    $weight = trim((string)$weight);
+    return preg_match('/^(100|200|300|400|500|600|700|800|900)$/', $weight) ? $weight : null;
+}
+
+if ($method === 'GET') {
+    $stmt = $pdo->prepare('SELECT value FROM site_settings WHERE name = :name');
+    $stmt->execute(['name' => 'accent_font_weight']);
+    $weight = $stmt->fetchColumn();
+    $sanitized = is_string($weight) ? sanitize_weight($weight) : null;
+    if ($sanitized === null) {
+        $sanitized = '600';
+    }
+    echo json_encode(['accent_font_weight' => $sanitized]);
+    exit;
+}
+
+if ($method === 'POST') {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input) || !array_key_exists('accent_font_weight', $input)) {
+        $input = $_POST;
+    }
+    $weight = $input['accent_font_weight'] ?? '';
+    $weight = sanitize_weight($weight);
+    if ($weight === null) {
+        http_response_code(422);
+        echo json_encode(['success' => false, 'error' => 'Invalid accent font weight value']);
+        exit;
+    }
+    $stmt = $pdo->prepare('INSERT INTO site_settings (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE value = VALUES(value)');
+    $stmt->execute(['name' => 'accent_font_weight', 'value' => $weight]);
+    echo json_encode(['success' => true, 'accent_font_weight' => $weight]);
+    exit;
+}
+
+http_response_code(405);
+header('Allow: GET, POST');
+echo json_encode(['error' => 'Method not allowed']);


### PR DESCRIPTION
## Summary
- persist the accent font weight in MySQL and expose a header control that applies the weight live across MQTT cards
- add a `settings.php` endpoint that saves validated accent font weight selections and provides UI feedback when updates succeed or fail
- document the new accent font weight behaviour in the README and AGENTS design log

## Testing
- php -l index.php
- php -l settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ca75810104832eb1401447cace4395