### PR TITLE
Refactor historical layouts and unify dark mode toggle

### DIFF
--- a/clear.php
+++ b/clear.php
@@ -50,76 +50,133 @@ try {
 // Round hours for output
 $monthHours = array_map(function ($h) { return round($h, 2); }, $monthHours);
 $monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+require_once 'layout.php';
+
+$pageTitle = 'Clear Observing by Month - Wheathampstead AstroPhotography Conditions';
+$heroTitle = 'Monthly Clear Sky Hours';
+$heroSubtitle = 'Review the cumulative safe observing time recorded by the observatory for each month.';
+$heroAside = '<div class="flex flex-col items-start gap-2">'
+    . '<span class="text-xs font-semibold uppercase tracking-widest text-indigo-500 dark:text-indigo-300">Selected Year</span>'
+    . '<span class="text-3xl font-bold text-gray-900 dark:text-gray-100">' . htmlspecialchars((string)$year, ENT_QUOTES) . '</span>'
+    . '</div>';
+$navActions = '<a href="historical.php?topic=safe" class="inline-flex items-center gap-2 rounded-full border border-indigo-200/70 bg-white/70 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-700 dark:border-indigo-700/60 dark:bg-gray-800/60 dark:text-indigo-200 dark:hover:text-indigo-100">'
+    . '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">'
+    . '<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 21h-2.5A2.75 2.75 0 0 1 3 18.25v-2.5m18 0v2.5A2.75 2.75 0 0 1 18.25 21h-2.5" />'
+    . '<path stroke-linecap="round" stroke-linejoin="round" d="M3 5.75v-2A.75.75 0 0 1 3.75 3h2a.75.75 0 0 1 .75.75V6M18.75 3h1.5a.75.75 0 0 1 .75.75v1.5M21 18v.75a.75.75 0 0 1-.75.75H18" />'
+    . '<path stroke-linecap="round" stroke-linejoin="round" d="M6 6h12v12H6z" />'
+    . '</svg>'
+    . '<span>Safe Trend</span>'
+    . '</a>';
+
+layout_start($pageTitle, $heroTitle, $heroSubtitle, [
+    'extraHead' => '<script src="https://code.highcharts.com/highcharts.js"></script>',
+    'navActions' => $navActions,
+    'heroAside' => $heroAside,
+]);
 ?>
-<!DOCTYPE html>
-<html class="h-full" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Clear Observing by Month - Wheathampstead AstroPhotography Conditions</title>
-    <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-        }
-    </script>
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-</head>
-<body class="min-h-screen bg-gradient-to-br from-indigo-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
-    <div class="max-w-4xl mx-auto p-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-xl shadow-lg">
-        <a href="index.php" class="mb-4 inline-block text-indigo-600 dark:text-indigo-400 hover:underline">&larr; Back to Home</a>
-        <div class="flex justify-between items-center mb-6 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-4 rounded-lg shadow">
-            <h1 class="text-2xl font-bold">Clear Nights by Month</h1>
-            <button id="modeToggle" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Switch to Dark Mode</button>
+<section>
+    <div class="space-y-6 rounded-3xl bg-white/70 p-6 shadow dark:bg-gray-800/70">
+        <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div class="space-y-1">
+                <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Compare observing seasons</h2>
+                <p class="text-sm text-gray-600 dark:text-gray-400">Select a year to chart monthly totals of safe observing hours.</p>
+            </div>
+            <form method="get" class="grid grid-cols-1 gap-3 sm:grid-cols-[auto_auto] sm:items-end">
+                <label class="flex flex-col gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                    <span>Observation year</span>
+                    <select name="year" class="w-full rounded-xl border border-indigo-200 bg-white/80 px-3 py-2 text-base font-semibold text-gray-800 shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-indigo-700/50 dark:bg-gray-900/60 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-600/40">
+                        <?php foreach ($years as $y): ?>
+                            <option value="<?= htmlspecialchars($y) ?>" <?= $y == $year ? 'selected' : '' ?>><?= htmlspecialchars($y) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full bg-indigo-500 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-500">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m-15 0 4.5 4.5M4.5 12l4.5-4.5" />
+                    </svg>
+                    <span>Update</span>
+                </button>
+            </form>
         </div>
-        <form method="get" class="mb-6 flex items-end gap-4">
-            <label class="flex flex-col">
-                <span>Year</span>
-                <select name="year" class="border rounded px-2 py-1 bg-white dark:bg-gray-700">
-                    <?php foreach ($years as $y): ?>
-                    <option value="<?= htmlspecialchars($y) ?>" <?= $y == $year ? 'selected' : '' ?>><?= htmlspecialchars($y) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <button type="submit" class="px-3 py-1 rounded bg-indigo-500 text-white hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700">Apply</button>
-        </form>
-        <div id="monthChart" class="bg-white/70 dark:bg-gray-800/70 p-4 rounded-xl shadow"></div>
+        <div id="monthChart" class="h-[28rem] w-full"></div>
     </div>
-    <script>
-    const monthNames = <?php echo json_encode($monthNames); ?>;
-    const monthData = <?php echo json_encode(array_values($monthHours)); ?>;
-    const chart = Highcharts.chart('monthChart', {
-        chart: { type: 'column' },
-        title: { text: 'Safe Observing Hours in ' + <?php echo json_encode($year); ?> },
-        xAxis: { categories: monthNames },
-        yAxis: { title: { text: 'Hours' } },
-        series: [{ name: 'Hours', data: monthData }]
-    });
-    const modeToggle = document.getElementById('modeToggle');
-    function updateChartTheme() {
-        const isDark = document.documentElement.classList.contains('dark');
-        const textColor = isDark ? '#F9FAFB' : '#1F2937';
-        const bgColor = isDark ? '#1f2937' : '#FFFFFF';
-        const gridColor = isDark ? '#374151' : '#e5e7eb';
-        chart.update({
-            chart: { backgroundColor: bgColor },
+</section>
+<?php
+$monthNamesJson = json_encode($monthNames);
+$monthDataJson = json_encode(array_values($monthHours));
+$yearJson = json_encode($year);
+
+$script = <<<SCRIPT
+<script>
+const monthNames = {$monthNamesJson};
+const monthData = {$monthDataJson};
+const chartYear = {$yearJson};
+
+const chart = Highcharts.chart('monthChart', {
+    chart: {
+        type: 'column',
+        backgroundColor: 'transparent',
+        style: { fontFamily: 'inherit' }
+    },
+    title: { text: null },
+    credits: { enabled: false },
+    legend: { enabled: false },
+    xAxis: {
+        categories: monthNames,
+        lineColor: 'transparent',
+        tickColor: 'transparent'
+    },
+    yAxis: {
+        title: { text: 'Safe observing hours' },
+        gridLineColor: '#E5E7EB'
+    },
+    tooltip: {
+        valueSuffix: ' hrs'
+    },
+    plotOptions: {
+        column: {
+            borderRadius: 6,
+            pointPadding: 0.1,
+            borderWidth: 0
+        }
+    },
+    series: [{
+        name: 'Safe hours in ' + chartYear,
+        data: monthData,
+        color: '#4F46E5'
+    }]
+});
+
+function updateChartTheme() {
+    const isDark = document.documentElement.classList.contains('dark');
+    const textColor = isDark ? '#F9FAFB' : '#1F2937';
+    const gridColor = isDark ? '#374151' : '#E5E7EB';
+    chart.update({
+        xAxis: {
+            labels: { style: { color: textColor } },
+            lineColor: 'transparent',
+            tickColor: 'transparent'
+        },
+        yAxis: {
+            labels: { style: { color: textColor } },
             title: { style: { color: textColor } },
-            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            legend: { itemStyle: { color: textColor } }
-        });
-    }
-    function updateModeText() {
-        modeToggle.textContent = document.documentElement.classList.contains('dark') ? 'Switch to Light Mode' : 'Switch to Dark Mode';
-    }
-    modeToggle.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        updateModeText();
-        updateChartTheme();
-    });
-    updateModeText();
-    updateChartTheme();
-    </script>
-</body>
-</html>
+            gridLineColor: gridColor
+        },
+        tooltip: {
+            backgroundColor: isDark ? 'rgba(17, 24, 39, 0.9)' : 'rgba(255, 255, 255, 0.9)',
+            style: { color: textColor }
+        },
+        series: [{
+            color: '#4F46E5'
+        }]
+    }, false);
+    chart.redraw();
+}
+
+document.addEventListener('themechange', updateChartTheme);
+updateChartTheme();
+</script>
+SCRIPT;
+
+layout_end($script);

--- a/layout.php
+++ b/layout.php
@@ -1,0 +1,113 @@
+<?php
+function layout_start(string $pageTitle, string $heroTitle, string $heroSubtitle = '', array $options = []): void
+{
+    $extraHead = $options['extraHead'] ?? '';
+    $navActions = $options['navActions'] ?? '';
+    $heroAside = $options['heroAside'] ?? '';
+    ?>
+<!DOCTYPE html>
+<html class="h-full" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($pageTitle); ?></title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+        };
+    </script>
+    <?php echo $extraHead; ?>
+</head>
+<body class="min-h-screen bg-gradient-to-br from-indigo-50 to-indigo-100 dark:from-gray-800 dark:to-gray-900 text-gray-800 dark:text-gray-100 font-sans">
+    <div class="min-h-screen">
+        <div class="max-w-6xl mx-auto px-6 py-10">
+            <header class="space-y-6 mb-10">
+                <div class="flex flex-wrap items-center justify-between gap-4 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-5 rounded-2xl shadow">
+                    <a href="index.php" class="flex items-center gap-3 text-indigo-600 dark:text-indigo-300 font-semibold hover:text-indigo-700 dark:hover:text-indigo-100 transition">
+                        <img src="favicon.svg" alt="" class="w-10 h-10">
+                        <span class="text-lg">Wheathampstead AstroPhotography Conditions</span>
+                    </a>
+                    <div class="flex items-center gap-3">
+                        <?php if ($navActions): ?>
+                            <?php echo $navActions; ?>
+                        <?php endif; ?>
+                        <button id="modeToggle" type="button" class="inline-flex items-center justify-center w-11 h-11 rounded-full bg-indigo-500 text-white shadow-md hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-500 transition" aria-live="polite">
+                            <span class="sr-only" id="modeToggleLabel">Toggle dark mode</span>
+                            <svg id="modeIconSun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5 hidden" fill="currentColor">
+                                <path d="M12 4.75a.75.75 0 0 0 .75-.75V2a.75.75 0 0 0-1.5 0v2a.75.75 0 0 0 .75.75Zm5.25 7.25a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0ZM4.75 12a.75.75 0 0 0-.75-.75H2a.75.75 0 0 0 0 1.5h2a.75.75 0 0 0 .75-.75Zm18 0a.75.75 0 0 0-.75-.75h-2a.75.75 0 0 0 0 1.5h2a.75.75 0 0 0 .75-.75ZM7.11 6.46a.75.75 0 0 0 0-1.06L5.7 4a.75.75 0 0 0-1.06 1.06l1.41 1.4a.75.75 0 0 0 1.06 0Zm12.25-.53 1.4-1.4A.75.75 0 1 0 19.7 3.47l-1.4 1.4a.75.75 0 1 0 1.06 1.06ZM12 19.25a.75.75 0 0 0-.75.75v2a.75.75 0 0 0 1.5 0v-2a.75.75 0 0 0-.75-.75Zm6.89-1.71a.75.75 0 0 0-1.06 0l-1.4 1.4a.75.75 0 0 0 1.06 1.06l1.4-1.4a.75.75 0 0 0 0-1.06ZM5.7 19.7a.75.75 0 1 0 1.06-1.06l-1.4-1.4a.75.75 0 0 0-1.06 1.06l1.4 1.4Z" />
+                            </svg>
+                            <svg id="modeIconMoon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5 hidden" fill="currentColor">
+                                <path d="M20.354 15.354a.75.75 0 0 0-.866-.18 6.5 6.5 0 0 1-8.662-8.662.75.75 0 0 0-.18-.866 8 8 0 1 0 9.708 9.708Z" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <div class="bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-3xl shadow-lg p-8">
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+                        <div class="space-y-3">
+                            <p class="text-sm font-semibold uppercase tracking-widest text-indigo-500 dark:text-indigo-300">Observatory Insights</p>
+                            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-50"><?php echo htmlspecialchars($heroTitle); ?></h1>
+                            <?php if ($heroSubtitle !== ''): ?>
+                                <p class="text-base text-gray-600 dark:text-gray-300"><?php echo htmlspecialchars($heroSubtitle); ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <?php if ($heroAside): ?>
+                            <div class="flex-shrink-0 text-sm text-gray-600 dark:text-gray-300">
+                                <?php echo $heroAside; ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </header>
+            <main class="space-y-10">
+<?php
+}
+
+function layout_end(string $extraScripts = ''): void
+{
+    ?>
+            </main>
+        </div>
+    </div>
+    <script>
+        (function() {
+            const root = document.documentElement;
+            const toggle = document.getElementById('modeToggle');
+            if (!toggle) return;
+            const label = document.getElementById('modeToggleLabel');
+            const sun = document.getElementById('modeIconSun');
+            const moon = document.getElementById('modeIconMoon');
+            const storedPreference = localStorage.getItem('color-theme');
+            if (storedPreference === 'dark' || (!storedPreference && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                root.classList.add('dark');
+            } else {
+                root.classList.remove('dark');
+            }
+            function syncState() {
+                const isDark = root.classList.contains('dark');
+                if (label) {
+                    label.textContent = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+                }
+                if (sun) {
+                    sun.classList.toggle('hidden', !isDark);
+                }
+                if (moon) {
+                    moon.classList.toggle('hidden', isDark);
+                }
+                localStorage.setItem('color-theme', isDark ? 'dark' : 'light');
+                document.dispatchEvent(new CustomEvent('themechange', { detail: { dark: isDark } }));
+            }
+            toggle.addEventListener('click', () => {
+                root.classList.toggle('dark');
+                syncState();
+            });
+            syncState();
+        })();
+    </script>
+    <?php echo $extraScripts; ?>
+</body>
+</html>
+<?php
+}


### PR DESCRIPTION
## Summary
- extract a shared layout include that delivers the hero, background gradient, and reusable dark-mode toggle
- update historical and clear views to use the layout and refresh their UI with Tailwind-styled controls
- add chart theme listeners tied to the shared toggle for consistent light/dark behavior

## Testing
- php -l layout.php
- php -l historical.php
- php -l clear.php

------
https://chatgpt.com/codex/tasks/task_e_68ca7ebdfad4832e956c0a7a14eceeab