### PR TITLE
Refresh telescope branding

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,13 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#1e3a8a"/>
-  <g fill="#ffffff" transform="translate(8,8)">
-    <!-- telescope body -->
-    <rect x="8" y="12" width="30" height="6" transform="rotate(-20 8 12)"/>
-    <!-- lens -->
-    <circle cx="9" cy="11" r="6"/>
-    <!-- tripod legs -->
-    <rect x="28" y="24" width="4" height="16"/>
-    <rect x="24" y="24" width="4" height="16" transform="rotate(20 24 24)"/>
-    <rect x="32" y="24" width="4" height="16" transform="rotate(-20 32 24)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Telescope favicon</title>
+  <desc id="desc">A stylised telescope pointing toward a glowing star field.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+    <radialGradient id="glow" cx="40" cy="16" r="22" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <circle cx="40" cy="18" r="18" fill="url(#glow)" />
+  <g fill="#f8fafc" opacity="0.9">
+    <circle cx="18" cy="14" r="1.4" />
+    <circle cx="50" cy="10" r="1" />
+    <circle cx="46" cy="28" r="1.2" />
+    <circle cx="30" cy="8" r="1" />
+  </g>
+  <g transform="translate(10 18)">
+    <path fill="#94a3b8" d="M19 17.5a2.5 2.5 0 1 1-5 0a2.5 2.5 0 0 1 5 0Z" />
+    <path fill="#f8fafc" d="m6 6l22.5 6.5l-2.8 8.5L3.2 14.5z" transform="rotate(-14 17 12.5)" />
+    <path fill="#38bdf8" d="M7.6 8.2a4.8 4.8 0 1 1 6.1 3.4z" />
+    <path fill="#cbd5f5" d="M17.2 19.2l4.1 10.8h-4.2L12 19.2z" />
+    <path fill="#cbd5f5" d="m21.8 19.2l6.7 10.8h-4.4l-2.3-7z" />
+    <path fill="#cbd5f5" d="m12.7 19.2-6 10.8H2.2l5-10.8z" />
+    <path fill="#f8fafc" d="M4 14.3h15.4l1.8 5H2.7z" />
   </g>
 </svg>

--- a/layout.php
+++ b/layout.php
@@ -26,7 +26,7 @@ function layout_start(string $pageTitle, string $heroTitle, string $heroSubtitle
             <header class="space-y-6 mb-10">
                 <div class="flex flex-wrap items-center justify-between gap-4 bg-white/70 dark:bg-gray-800/70 backdrop-blur p-5 rounded-2xl shadow">
                     <a href="index.php" class="flex items-center gap-3 text-indigo-600 dark:text-indigo-300 font-semibold hover:text-indigo-700 dark:hover:text-indigo-100 transition">
-                        <img src="favicon.svg" alt="" class="w-10 h-10">
+                        <img src="logo.svg" alt="Observatory telescope logo" class="w-10 h-10">
                         <span class="text-lg">Wheathampstead AstroPhotography Conditions</span>
                     </a>
                     <div class="flex items-center gap-3">

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Wheathampstead observatory telescope logo</title>
+  <desc id="logoDesc">Circular logo showing a telescope on a tripod aimed at a glowing sky with stars.</desc>
+  <defs>
+    <radialGradient id="halo" cx="55%" cy="32%" r="60%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="night" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="ground" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <circle cx="80" cy="80" r="74" fill="url(#night)" />
+  <circle cx="92" cy="46" r="54" fill="url(#halo)" />
+  <path d="M20 112h120v18a74 74 0 0 1-120 0z" fill="url(#ground)" opacity="0.9" />
+  <g fill="#f8fafc" opacity="0.85">
+    <circle cx="52" cy="34" r="3" />
+    <circle cx="116" cy="28" r="2.6" />
+    <circle cx="104" cy="72" r="2.4" />
+    <circle cx="72" cy="20" r="2.2" />
+    <path d="M127 56l2-5l5-2l-2 5z" />
+  </g>
+  <g transform="translate(28 42)">
+    <path fill="#cbd5f5" d="M40 60a6 6 0 1 1-12 0a6 6 0 0 1 12 0Z" />
+    <path fill="#f8fafc" d="M5 15l68 18l-6 20L0 32z" transform="rotate(-12 44 35)" />
+    <path fill="#38bdf8" d="M6 18.5a12 12 0 1 1 15.6 8.5z" />
+    <path fill="#e2e8f0" d="M38.5 65l12.5 36h-12L26 65z" />
+    <path fill="#e2e8f0" d="m54 65l24 36h-13.6l-7.4-22.2z" />
+    <path fill="#e2e8f0" d="m24.8 65-18 36H-4l15.8-36z" />
+    <path fill="#f8fafc" d="M-2 52h56l5 15H-8z" />
+  </g>
+  <circle cx="80" cy="80" r="74" fill="none" stroke="#38bdf8" stroke-width="4" opacity="0.35" />
+</svg>


### PR DESCRIPTION
## Summary
- replace the favicon with a telescope illustration highlighted against a night-sky gradient
- add a dedicated telescope-themed logo and update the site header to use it for branding consistency

## Testing
- php -l layout.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8a814428832e8456189ea12a9961