### PR TITLE
Enable zoom interactions for charts

### DIFF
--- a/clear.php
+++ b/clear.php
@@ -113,11 +113,30 @@ const monthNames = {$monthNamesJson};
 const monthData = {$monthDataJson};
 const chartYear = {$yearJson};
 
+function createResetZoomTheme(isDark) {
+    return {
+        fill: isDark ? '#1F2937' : '#EEF2FF',
+        stroke: 'transparent',
+        style: {
+            color: isDark ? '#E5E7EB' : '#312E81',
+            fontWeight: '600'
+        }
+    };
+}
+
 const chart = Highcharts.chart('monthChart', {
     chart: {
         type: 'column',
         backgroundColor: 'transparent',
-        style: { fontFamily: 'inherit' }
+        style: { fontFamily: 'inherit' },
+        zooming: {
+            type: 'x',
+            mouseWheel: true
+        },
+        zoomType: 'x',
+        resetZoomButton: {
+            theme: createResetZoomTheme(document.documentElement.classList.contains('dark'))
+        }
     },
     title: { text: null },
     credits: { enabled: false },
@@ -153,6 +172,11 @@ function updateChartTheme() {
     const textColor = isDark ? '#F9FAFB' : '#1F2937';
     const gridColor = isDark ? '#374151' : '#E5E7EB';
     chart.update({
+        chart: {
+            resetZoomButton: {
+                theme: createResetZoomTheme(isDark)
+            }
+        },
         xAxis: {
             labels: { style: { color: textColor } },
             lineColor: 'transparent',

--- a/historical.php
+++ b/historical.php
@@ -168,7 +168,15 @@ const histChart = Highcharts.stockChart('histChart', {
     chart: {
         type: 'line',
         backgroundColor: 'transparent',
-        style: { fontFamily: 'inherit' }
+        style: { fontFamily: 'inherit' },
+        zooming: {
+            type: 'x',
+            mouseWheel: true
+        },
+        zoomType: 'x',
+        resetZoomButton: {
+            theme: createButtonTheme(document.documentElement.classList.contains('dark'))
+        }
     },
     title: { text: null },
     legend: { enabled: false },
@@ -229,6 +237,11 @@ function updateChartTheme() {
     const textColor = isDark ? '#F9FAFB' : '#1F2937';
     const gridColor = isDark ? '#374151' : '#E5E7EB';
     histChart.update({
+        chart: {
+            resetZoomButton: {
+                theme: createButtonTheme(isDark)
+            }
+        },
         xAxis: {
             labels: { style: { color: textColor } },
             gridLineColor: gridColor,

--- a/index.php
+++ b/index.php
@@ -392,7 +392,14 @@ let envChart = null;
     const safeCategories = safeData.map(r => r.day);
     const safeHours = safeData.map(r => parseFloat(r.hours));
     const safeChart = Highcharts.chart('safeChart', {
-        chart: { type: 'column' },
+        chart: {
+            type: 'column',
+            zooming: {
+                type: 'x',
+                mouseWheel: true
+            },
+            zoomType: 'x'
+        },
         title: { text: 'Observable Hours (Last 30 Days)' },
         xAxis: { categories: safeCategories },
         yAxis: { title: { text: 'Hours' } },
@@ -402,7 +409,14 @@ let envChart = null;
     function ensureEnvChart() {
         if (envChart) return envChart;
         envChart = Highcharts.chart('envChart', {
-            chart: { type: 'spline' },
+            chart: {
+                type: 'spline',
+                zooming: {
+                    type: 'x',
+                    mouseWheel: true
+                },
+                zoomType: 'x'
+            },
             title: { text: 'Realtime Clouds, Light, SQM' },
             xAxis: { type: 'datetime' },
             series: envSeriesLabels.map((name, idx) => ({ name, data: envSeriesData[idx].slice() }))
@@ -505,14 +519,27 @@ let envChart = null;
         const gridColor = isDark ? '#374151' : '#e5e7eb';
         const charts = [safeChart];
         if (envChart) charts.push(envChart);
-        charts.forEach(c => c.update({
-            chart: { backgroundColor: bgColor },
-            title: { style: { color: textColor } },
-            xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
-            legend: { itemStyle: { color: textColor } }
-        }, false));
-        charts.forEach(c => c.redraw());
+        charts.forEach(c => {
+            const resetZoomTheme = {
+                fill: isDark ? '#1F2937' : '#EEF2FF',
+                stroke: 'transparent',
+                style: {
+                    color: textColor,
+                    fontWeight: '600'
+                }
+            };
+            c.update({
+                chart: {
+                    backgroundColor: bgColor,
+                    resetZoomButton: { theme: resetZoomTheme }
+                },
+                title: { style: { color: textColor } },
+                xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+                yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
+                legend: { itemStyle: { color: textColor } }
+            }, false);
+            c.redraw();
+        });
     }
 
     function updateModeIcon() {


### PR DESCRIPTION
## Summary
- enable mouse wheel and drag-to-zoom interactions for the dashboard safe-hours and realtime charts, while keeping their reset buttons styled with the active theme
- add matching zoom controls to the historical trend explorer, ensuring the reset control respects light and dark modes
- extend the monthly clear-hours chart with reusable reset-button theming so zooming works consistently across pages

## Testing
- php -l index.php
- php -l historical.php
- php -l clear.php

------
https://chatgpt.com/codex/tasks/task_e_68cbbca87dd4832e9313c7667b908149