### PR TITLE
docs: add job for clear.php year boundary aggregation bug

### DIFF
--- a/jobs/2026-03-07-clear-page-year-boundary-bug.md
+++ b/jobs/2026-03-07-clear-page-year-boundary-bug.md
@@ -1,0 +1,33 @@
+# Job: Fix yearly boundary bug in `clear.php` monthly safe-hours aggregation
+
+## Status
+Open
+
+## Problem statement
+The yearly aggregation query in `clear.php` currently uses:
+
+```sql
+WHERE dateTime BETWEEN :start AND :end
+```
+
+with `:end` set to `YYYY+1-01-01 00:00:00`.
+
+Because `BETWEEN` is inclusive, a row exactly at midnight on January 1st of the following year is incorrectly included in the selected year totals. This can misattribute time to January in the selected year.
+
+## Impact
+- Monthly totals on the **Clear / Monthly View** page can be slightly inflated for January.
+- The displayed data can be inconsistent with year-based reporting expectations.
+
+## Proposed fix
+1. Change the SQL range predicate to a half-open interval:
+   - `dateTime >= :start AND dateTime < :end`
+2. Apply the same half-open interval rule to the `lastStmt` query so record selection for carry-forward logic matches the aggregation window.
+3. Add a code comment documenting why half-open ranges are used for period boundaries.
+
+## Acceptance criteria
+- Selecting year `Y` never includes rows where `dateTime >= (Y+1)-01-01 00:00:00`.
+- A record exactly at `(Y+1)-01-01 00:00:00` is excluded from year `Y` and included only in year `Y+1`.
+- `php -l clear.php` passes.
+
+## Notes
+This job avoids any database-dependent testing in local CI; validation can be done with a targeted SQL fixture or in staging where DB access is available.


### PR DESCRIPTION
### Motivation
- A static review found a boundary-condition bug in `clear.php` where the yearly aggregation uses an inclusive `BETWEEN :start AND :end` while `:end` is set to `YYYY+1-01-01 00:00:00`, which can incorrectly include a record at the following year's midnight in the selected year totals.

### Description
- Added a job document at `jobs/2026-03-07-clear-page-year-boundary-bug.md` that describes the problem, impact, proposed fix (use a half-open interval `dateTime >= :start AND dateTime < :end`), and acceptance criteria so remediation can be implemented and tracked.

### Testing
- Ran syntax checks with `php -l` on `clear.php`, `historical.php`, `index.php`, and `layout.php`, and all returned "No syntax errors detected."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf3bd89c4832ebeaea27356da7093)