### PR TITLE
Remove index card gradients and add HA hub display page

### DIFF
--- a/HA.php
+++ b/HA.php
@@ -1,0 +1,133 @@
+<?php
+$config = json_decode(file_get_contents('mqtt_config.json'), true);
+$host = $config['host'] ?? 'localhost';
+$topics = $config['topics'] ?? [];
+$cloudsTopic = $topics['clouds']['topic'] ?? 'Observatory/clouds';
+$sqmTopic = $topics['sqm']['topic'] ?? 'Observatory/sqm';
+$cloudsUnit = $topics['clouds']['unit'] ?? '';
+$sqmUnit = $topics['sqm']['unit'] ?? '';
+?>
+<!DOCTYPE html>
+<html class="h-full" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HA Display | Wheathampstead AstroPhotography Conditions</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+</head>
+<body class="h-full bg-slate-950 text-slate-100 font-sans">
+    <main class="flex h-full min-h-screen flex-col items-center justify-center gap-16 px-8 py-10 text-center">
+        <h1 class="text-3xl font-semibold tracking-wide text-slate-300">Observatory Conditions</h1>
+
+        <section class="w-full max-w-5xl space-y-10">
+            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-10 shadow-2xl">
+                <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">Clouds</p>
+                <p class="mt-4 text-[8rem] font-bold leading-none sm:text-[10rem]" id="cloudsValue">--</p>
+                <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($cloudsUnit, ENT_QUOTES, 'UTF-8'); ?></p>
+            </div>
+
+            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-10 shadow-2xl">
+                <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">SQM</p>
+                <p class="mt-4 text-[8rem] font-bold leading-none sm:text-[10rem]" id="sqmValue">--</p>
+                <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($sqmUnit, ENT_QUOTES, 'UTF-8'); ?></p>
+            </div>
+        </section>
+
+        <p id="mqttStatus" class="text-2xl font-semibold text-amber-300">Connecting to MQTT...</p>
+    </main>
+
+    <script>
+        const host = <?php echo json_encode($host); ?>;
+        const cloudsTopic = <?php echo json_encode($cloudsTopic); ?>;
+        const sqmTopic = <?php echo json_encode($sqmTopic); ?>;
+        const port = 8083;
+        const brokerHost = (host === 'localhost' || host === '127.0.0.1') ? window.location.hostname : host;
+
+        const cloudsEl = document.getElementById('cloudsValue');
+        const sqmEl = document.getElementById('sqmValue');
+        const statusEl = document.getElementById('mqttStatus');
+
+        let client = null;
+        let connectAttempts = 0;
+
+        function updateStatus(message, className) {
+            statusEl.textContent = message;
+            statusEl.className = className;
+        }
+
+        function scheduleReconnect() {
+            const delay = Math.min(1000 * Math.pow(2, connectAttempts), 30000);
+            updateStatus('Reconnecting to MQTT...', 'text-2xl font-semibold text-amber-300');
+            setTimeout(() => {
+                connectAttempts++;
+                connectClient();
+            }, delay);
+        }
+
+        function connectClient() {
+            if (!window.mqtt) {
+                updateStatus('MQTT unavailable', 'text-2xl font-semibold text-rose-400');
+                return;
+            }
+
+            const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+            client = mqtt.connect(`${protocol}://${brokerHost}:${port}`, {
+                reconnectPeriod: 0,
+                clientId: 'ha-display-' + Math.random()
+            });
+
+            client.on('connect', () => {
+                updateStatus('Connected', 'text-2xl font-semibold text-emerald-400');
+                connectAttempts = 0;
+                client.subscribe(cloudsTopic);
+                client.subscribe(sqmTopic);
+            });
+
+            client.on('message', (topic, message) => {
+                const rawValue = message.toString();
+                const numericValue = parseFloat(rawValue);
+                const display = Number.isFinite(numericValue)
+                    ? numericValue.toLocaleString(undefined, {
+                        minimumFractionDigits: 0,
+                        maximumFractionDigits: 2,
+                        useGrouping: false
+                    })
+                    : rawValue;
+
+                if (topic === cloudsTopic) cloudsEl.textContent = display;
+                if (topic === sqmTopic) sqmEl.textContent = display;
+            });
+
+            client.on('close', () => {
+                updateStatus('Disconnected', 'text-2xl font-semibold text-rose-400');
+                scheduleReconnect();
+            });
+
+            client.on('error', () => {
+                updateStatus('MQTT error', 'text-2xl font-semibold text-rose-400');
+            });
+        }
+
+        function loadMQTT(urls, idx = 0) {
+            if (idx >= urls.length) {
+                updateStatus('MQTT unavailable', 'text-2xl font-semibold text-rose-400');
+                return;
+            }
+            const script = document.createElement('script');
+            script.src = urls[idx];
+            script.onload = connectClient;
+            script.onerror = () => loadMQTT(urls, idx + 1);
+            document.head.appendChild(script);
+        }
+
+        loadMQTT([
+            'https://unpkg.com/mqtt/dist/mqtt.min.js',
+            'https://cdn.jsdelivr.net/npm/mqtt/dist/mqtt.min.js'
+        ]);
+    </script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -242,12 +242,6 @@ let envChart = null;
         dewpoint: '❄️'
     };
 
-    const gradientPalettes = [
-        'from-indigo-500/20 via-white/80 to-white/50 dark:from-indigo-500/20 dark:via-slate-900/70 dark:to-slate-900/40',
-        'from-sky-500/20 via-white/80 to-white/50 dark:from-sky-500/20 dark:via-slate-900/70 dark:to-slate-900/40',
-        'from-purple-500/20 via-white/80 to-white/50 dark:from-purple-500/20 dark:via-slate-900/70 dark:to-slate-900/40',
-        'from-emerald-500/20 via-white/80 to-white/50 dark:from-emerald-500/20 dark:via-slate-900/70 dark:to-slate-900/40'
-    ];
     const statusBaseClasses = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-sm ring-1 ring-inset transition-colors backdrop-blur-sm';
 
     const miniChartData = {};
@@ -406,13 +400,12 @@ let envChart = null;
             });
     }
 
-    topicEntries.forEach(([name, cfg], idx) => {
+    topicEntries.forEach(([name, cfg]) => {
         const id = 'value-' + sanitize(name);
         const card = document.createElement('div');
-        const gradient = gradientPalettes[idx % gradientPalettes.length];
 
         card.id = 'card-' + sanitize(name);
-        card.className = `relative flex h-full flex-col overflow-hidden rounded-3xl bg-gradient-to-br ${gradient} p-6 shadow-xl shadow-indigo-200/60 dark:shadow-black/40 ring-1 ring-white/40 dark:ring-white/10 transition`; 
+        card.className = 'relative flex h-full flex-col overflow-hidden rounded-3xl bg-white/90 p-6 shadow-xl shadow-indigo-200/60 ring-1 ring-white/40 transition dark:bg-slate-900/85 dark:shadow-black/40 dark:ring-white/10';
         const icon = icons[name] || '📟';
         const label = name.replace(/[_-]/g, ' ');
         const unitMarkup = cfg.unit ? `<span class="ml-1 text-lg font-medium text-slate-500 dark:text-slate-300">${cfg.unit}</span>` : '';


### PR DESCRIPTION
### Motivation
- Improve readability and visual consistency by removing colorful gradients from per-sensor cards on the index page. 
- Provide a simple, high-contrast page optimized for a Google Home Hub to display the key remote-read values (Clouds and SQM) in very large font for distance readability.

### Description
- Replaced per-card gradient backgrounds in `index.php` with solid/light–dark surfaces using `bg-white/90` for light mode and `dark:bg-slate-900/85`, and removed the gradient palette and index usage. 
- Adjusted the `topicEntries.forEach` usage to no longer rely on the removed gradient index. 
- Added `HA.php`, a minimal full-screen display that reads `mqtt_config.json` for the Clouds and SQM topics and renders only those two values in very large type for a hub display. 
- Implemented live MQTT updates in `HA.php` using MQTT.js with CDN fallbacks and an exponential-backoff reconnect strategy plus a connection status indicator.

### Testing
- Ran PHP syntax checks with `php -l index.php` and `php -l HA.php`, both reported no syntax errors. 
- Launched a local dev server with `php -S` and captured render verification screenshots for `index.php` and `HA.php` via a Playwright script, which completed successfully. 
- No database-dependent tests were run per the instructions not to execute tests requiring DB access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14518a3f8832eaf22e651be647333)