### PR TITLE
Adjust HA display sizing and two-column layout

### DIFF
--- a/HA.php
+++ b/HA.php
@@ -20,19 +20,19 @@ $sqmUnit = $topics['sqm']['unit'] ?? '';
     </script>
 </head>
 <body class="h-full bg-slate-950 text-slate-100 font-sans">
-    <main class="flex h-full min-h-screen flex-col items-center justify-center gap-16 px-8 py-10 text-center">
+    <main class="flex h-full min-h-screen flex-col items-center justify-center gap-12 px-8 py-8 text-center">
         <h1 class="text-3xl font-semibold tracking-wide text-slate-300">Observatory Conditions</h1>
 
-        <section class="w-full max-w-5xl space-y-10">
-            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-10 shadow-2xl">
+        <section class="grid w-full max-w-6xl grid-cols-2 gap-8">
+            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-8 shadow-2xl">
                 <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">Clouds</p>
-                <p class="mt-4 text-[8rem] font-bold leading-none sm:text-[10rem]" id="cloudsValue">--</p>
+                <p class="mt-4 text-[6.8rem] font-bold leading-none sm:text-[8.5rem]" id="cloudsValue">--</p>
                 <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($cloudsUnit, ENT_QUOTES, 'UTF-8'); ?></p>
             </div>
 
-            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-10 shadow-2xl">
+            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-8 shadow-2xl">
                 <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">SQM</p>
-                <p class="mt-4 text-[8rem] font-bold leading-none sm:text-[10rem]" id="sqmValue">--</p>
+                <p class="mt-4 text-[6.8rem] font-bold leading-none sm:text-[8.5rem]" id="sqmValue">--</p>
                 <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($sqmUnit, ENT_QUOTES, 'UTF-8'); ?></p>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Reduce the vertical footprint of the HA display by ~15% so the page is slightly shorter and better fits intended screens.
- Present the Clouds and SQM values side-by-side instead of stacked to make it easier to compare metrics at a glance.

### Description
- Converted the main metrics container in `HA.php` from a vertical stacked layout to a two-column Tailwind grid (`grid-cols-2`).
- Tightened page spacing by reducing the main container gap and padding (`gap-16` → `gap-12`, `py-10` → `py-8`) and reduced card padding (`p-10` → `p-8`).
- Scaled down the large metric typography for both values (`text-[8rem]/sm:text-[10rem]` → `text-[6.8rem]/sm:text-[8.5rem]`) to achieve the ~15% reduction while keeping readability.
- Adjusted `max-w-5xl` → `max-w-6xl` to accommodate the two-column layout without wrapping.

### Testing
- Ran a PHP syntax check with `php -l HA.php`, which reported no syntax errors and succeeded.
- Attempted an automated Playwright render/screenshot for visual validation, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot could be produced (test failed due to environment, not the PHP changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1485e6f7c832ea355b63d0d6b9b30)