### PR TITLE
Add professional space-age observatory interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,4 +47,5 @@ Design decisions added after this file should be appended here for future refere
 38. Historical pages load all available data by default, removing the previous seven-day query limit.
 39. Historical queries accept optional `start` or `end` parameters to filter results without requiring both.
 40. Historical pages fetch data asynchronously via a JSON endpoint to handle large result sets without exhausting server memory.
-
+41. The interface uses a professional observatory-console visual system: deep orbital backgrounds, restrained cyan and violet telemetry accents, technical labels, translucent instrument panels, and consistent styles across dashboard, archive, history, and wall-display pages.
+42. Decorative space visuals are implemented with lightweight CSS and SVG so the site remains responsive and does not depend on large generated image assets.

--- a/HA.php
+++ b/HA.php
@@ -8,36 +8,42 @@ $cloudsUnit = $topics['clouds']['unit'] ?? '';
 $sqmUnit = $topics['sqm']['unit'] ?? '';
 ?>
 <!DOCTYPE html>
-<html class="h-full" lang="en">
+<html class="h-full dark" lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HA Display | Wheathampstead AstroPhotography Conditions</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="observatory.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = { darkMode: 'class' };
     </script>
 </head>
-<body class="h-full bg-slate-950 text-slate-100 font-sans">
-    <main class="flex h-full min-h-screen flex-col items-center justify-center gap-12 px-8 py-8 text-center">
-        <h1 class="text-3xl font-semibold tracking-wide text-slate-300">Observatory Conditions</h1>
+<body class="observatory-shell h-full text-slate-100">
+    <main class="relative z-10 flex h-full min-h-screen flex-col items-center justify-center gap-9 px-8 py-8 text-center">
+        <header>
+            <p class="obs-kicker text-cyan-300">WAC · Operations display</p>
+            <h1 class="mt-3 text-3xl font-semibold tracking-tight text-slate-100">Observatory Conditions</h1>
+        </header>
 
-        <section class="grid w-full max-w-6xl grid-cols-2 gap-8">
-            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-8 shadow-2xl">
-                <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">Clouds</p>
-                <p class="mt-4 text-[6.8rem] font-bold leading-none sm:text-[8.5rem]" id="cloudsValue">--</p>
-                <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($cloudsUnit, ENT_QUOTES, 'UTF-8'); ?></p>
+        <section class="grid w-full max-w-6xl grid-cols-1 gap-5 md:grid-cols-2 md:gap-8">
+            <div class="obs-panel p-8">
+                <p class="obs-data-label text-cyan-300">ATM-04 · Cloud sensor</p>
+                <p class="mt-5 text-3xl font-medium uppercase tracking-[0.18em] text-slate-300">Clouds</p>
+                <p class="mt-5 font-mono text-[4.8rem] font-semibold leading-none tracking-[-0.08em] text-cyan-200 sm:text-[6.8rem] lg:text-[8.5rem]" id="cloudsValue">--</p>
+                <p class="mt-2 font-mono text-3xl font-semibold text-slate-400"><?php echo htmlspecialchars($cloudsUnit, ENT_QUOTES, 'UTF-8'); ?></p>
             </div>
 
-            <div class="rounded-3xl border border-slate-700 bg-slate-900/80 p-8 shadow-2xl">
-                <p class="text-4xl font-medium uppercase tracking-[0.2em] text-slate-300">SQM</p>
-                <p class="mt-4 text-[6.8rem] font-bold leading-none sm:text-[8.5rem]" id="sqmValue">--</p>
-                <p class="text-4xl font-semibold text-slate-300"><?php echo htmlspecialchars($sqmUnit, ENT_QUOTES, 'UTF-8'); ?></p>
+            <div class="obs-panel p-8">
+                <p class="obs-data-label text-violet-300">SKY-06 · Quality meter</p>
+                <p class="mt-5 text-3xl font-medium uppercase tracking-[0.18em] text-slate-300">SQM</p>
+                <p class="mt-5 font-mono text-[4.8rem] font-semibold leading-none tracking-[-0.08em] text-violet-200 sm:text-[6.8rem] lg:text-[8.5rem]" id="sqmValue">--</p>
+                <p class="mt-2 font-mono text-3xl font-semibold text-slate-400"><?php echo htmlspecialchars($sqmUnit, ENT_QUOTES, 'UTF-8'); ?></p>
             </div>
         </section>
 
-        <p id="mqttStatus" class="text-2xl font-semibold text-amber-300">Connecting to MQTT...</p>
+        <p id="mqttStatus" class="obs-status-pill text-base">MQTT · Connecting</p>
     </main>
 
     <script>
@@ -56,12 +62,12 @@ $sqmUnit = $topics['sqm']['unit'] ?? '';
 
         function updateStatus(message, className) {
             statusEl.textContent = message;
-            statusEl.className = className;
+            statusEl.className = 'obs-status-pill text-base ' + className;
         }
 
         function scheduleReconnect() {
             const delay = Math.min(1000 * Math.pow(2, connectAttempts), 30000);
-            updateStatus('Reconnecting to MQTT...', 'text-2xl font-semibold text-amber-300');
+            updateStatus('MQTT · Reconnecting', 'obs-status-pill--warn');
             setTimeout(() => {
                 connectAttempts++;
                 connectClient();
@@ -70,7 +76,7 @@ $sqmUnit = $topics['sqm']['unit'] ?? '';
 
         function connectClient() {
             if (!window.mqtt) {
-                updateStatus('MQTT unavailable', 'text-2xl font-semibold text-rose-400');
+                updateStatus('MQTT · Unavailable', 'obs-status-pill--bad');
                 return;
             }
 
@@ -81,7 +87,7 @@ $sqmUnit = $topics['sqm']['unit'] ?? '';
             });
 
             client.on('connect', () => {
-                updateStatus('Connected', 'text-2xl font-semibold text-emerald-400');
+                updateStatus('MQTT · Connected', 'obs-status-pill--ok');
                 connectAttempts = 0;
                 client.subscribe(cloudsTopic);
                 client.subscribe(sqmTopic);
@@ -103,18 +109,18 @@ $sqmUnit = $topics['sqm']['unit'] ?? '';
             });
 
             client.on('close', () => {
-                updateStatus('Disconnected', 'text-2xl font-semibold text-rose-400');
+                updateStatus('MQTT · Disconnected', 'obs-status-pill--bad');
                 scheduleReconnect();
             });
 
             client.on('error', () => {
-                updateStatus('MQTT error', 'text-2xl font-semibold text-rose-400');
+                updateStatus('MQTT · Error', 'obs-status-pill--bad');
             });
         }
 
         function loadMQTT(urls, idx = 0) {
             if (idx >= urls.length) {
-                updateStatus('MQTT unavailable', 'text-2xl font-semibold text-rose-400');
+                updateStatus('MQTT · Unavailable', 'obs-status-pill--bad');
                 return;
             }
             const script = document.createElement('script');

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wheathampstead AstroPhotography Conditions
 
-Website that publicly shows observatory sensor data. The site displays live and historical sensor readings with a modern interface.
+Website that publicly shows observatory sensor data. The site displays live and historical sensor readings through a professional, space-age telemetry interface designed around the observatory's own instruments.
 
 ## Features
 
@@ -14,6 +14,8 @@ Website that publicly shows observatory sensor data. The site displays live and 
 
 - Historical pages accept optional `start` and `end` query parameters (`YYYY-MM-DD`) to limit the data returned
 - Clear page shows safe observing hours aggregated by month for a selected year
+- Shared observatory-console design across the dashboard, archive, history, and wall-display pages
+- Lightweight CSS/SVG orbital visuals with no large decorative image downloads
 
 ## Sensor Data Tables
 

--- a/clear.php
+++ b/clear.php
@@ -47,6 +47,9 @@ try {
 } catch (Exception $e) {
     $monthHours = array_fill(1, 12, 0.0);
 }
+if (empty($years)) {
+    $years = [$year];
+}
 // Round hours for output
 $monthHours = array_map(function ($h) { return round($h, 2); }, $monthHours);
 $monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -54,44 +57,46 @@ $monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov'
 require_once 'layout.php';
 
 $pageTitle = 'Clear Observing by Month - Wheathampstead AstroPhotography Conditions';
-$heroTitle = 'Monthly Clear Sky Hours';
-$heroSubtitle = 'Review the cumulative safe observing time recorded by the observatory for each month.';
-$heroAside = '<div class="flex flex-col items-start gap-2">'
-    . '<span class="text-xs font-semibold uppercase tracking-widest text-sky-700 dark:text-sky-300">Selected Year</span>'
-    . '<span class="text-3xl font-bold text-slate-900 dark:text-slate-100">' . htmlspecialchars((string)$year, ENT_QUOTES) . '</span>'
+$heroTitle = 'Clear-sky archive';
+$heroSubtitle = 'Compare the observing windows recorded by the local sensor array across every month of the year.';
+$heroAside = '<div class="flex flex-col items-start gap-2 border-l border-cyan-300/30 pl-5">'
+    . '<span class="obs-data-label text-cyan-300">Selected cycle</span>'
+    . '<span class="font-mono text-3xl font-semibold text-white">' . htmlspecialchars((string)$year, ENT_QUOTES) . '</span>'
     . '</div>';
-$navActions = '<a href="historical.php?topic=safe" class="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800">'
+$navActions = '<a href="historical.php?topic=safe" class="obs-nav-link">'
     . '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">'
     . '<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 21h-2.5A2.75 2.75 0 0 1 3 18.25v-2.5m18 0v2.5A2.75 2.75 0 0 1 18.25 21h-2.5" />'
     . '<path stroke-linecap="round" stroke-linejoin="round" d="M3 5.75v-2A.75.75 0 0 1 3.75 3h2a.75.75 0 0 1 .75.75V6M18.75 3h1.5a.75.75 0 0 1 .75.75v1.5M21 18v.75a.75.75 0 0 1-.75.75H18" />'
     . '<path stroke-linecap="round" stroke-linejoin="round" d="M6 6h12v12H6z" />'
     . '</svg>'
-    . '<span>Safe Trend</span>'
+    . '<span class="obs-nav-label">Safe trend</span>'
     . '</a>';
 
 layout_start($pageTitle, $heroTitle, $heroSubtitle, [
-    'extraHead' => '<script src="https://code.highcharts.com/highcharts.js"></script>',
+    'extraHead' => '<script src="https://code.highcharts.com/highcharts.js"></script>'
+        . '<script src="https://code.highcharts.com/modules/accessibility.js"></script>',
     'navActions' => $navActions,
     'heroAside' => $heroAside,
 ]);
 ?>
 <section>
-    <div class="space-y-6 border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+    <div class="obs-panel space-y-6">
         <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
             <div class="space-y-1">
+                <p class="obs-data-label">ANL-03 · Seasonal yield</p>
                 <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">Compare observing seasons</h2>
                 <p class="text-sm text-slate-600 dark:text-slate-400">Select a year to chart monthly totals of safe observing hours.</p>
             </div>
             <form method="get" class="grid grid-cols-1 gap-3 sm:grid-cols-[auto_auto] sm:items-end">
                 <label class="flex flex-col gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
                     <span>Observation year</span>
-                    <select name="year" class="w-full rounded-xl border border-indigo-200 bg-white/80 px-3 py-2 text-base font-semibold text-gray-800 shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-indigo-700/50 dark:bg-gray-900/60 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-600/40">
+                    <select name="year" class="obs-select w-full">
                         <?php foreach ($years as $y): ?>
                             <option value="<?= htmlspecialchars($y) ?>" <?= $y == $year ? 'selected' : '' ?>><?= htmlspecialchars($y) ?></option>
                         <?php endforeach; ?>
                     </select>
                 </label>
-                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-md bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-sky-600 dark:hover:bg-sky-500">
+                <button type="submit" class="obs-button obs-button--primary">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m-15 0 4.5 4.5M4.5 12l4.5-4.5" />
                     </svg>
@@ -115,10 +120,10 @@ const chartYear = {$yearJson};
 
 function createResetZoomTheme(isDark) {
     return {
-        fill: isDark ? '#1F2937' : '#EEF2FF',
+        fill: isDark ? '#0B1324' : '#ECFEFF',
         stroke: 'transparent',
         style: {
-            color: isDark ? '#E5E7EB' : '#312E81',
+            color: isDark ? '#67E8F9' : '#0E7490',
             fontWeight: '600'
         }
     };
@@ -138,7 +143,8 @@ const chart = Highcharts.chart('monthChart', {
             theme: createResetZoomTheme(document.documentElement.classList.contains('dark'))
         }
     },
-    title: { text: null },
+    title: { text: 'Monthly clear-sky yield', align: 'left' },
+    subtitle: { text: 'Recorded safe observing hours for ' + chartYear, align: 'left' },
     credits: { enabled: false },
     legend: { enabled: false },
     xAxis: {
@@ -163,20 +169,22 @@ const chart = Highcharts.chart('monthChart', {
     series: [{
         name: 'Safe hours in ' + chartYear,
         data: monthData,
-        color: '#4F46E5'
+        color: '#0891B2'
     }]
 });
 
 function updateChartTheme() {
     const isDark = document.documentElement.classList.contains('dark');
     const textColor = isDark ? '#F9FAFB' : '#1F2937';
-    const gridColor = isDark ? '#374151' : '#E5E7EB';
+    const gridColor = isDark ? 'rgba(148, 163, 184, 0.14)' : 'rgba(15, 23, 42, 0.09)';
     chart.update({
         chart: {
             resetZoomButton: {
                 theme: createResetZoomTheme(isDark)
             }
         },
+        title: { style: { color: textColor, fontSize: '15px', fontWeight: '650' } },
+        subtitle: { style: { color: isDark ? '#91A2B8' : '#64748B', fontSize: '11px' } },
         xAxis: {
             labels: { style: { color: textColor } },
             lineColor: 'transparent',
@@ -192,7 +200,7 @@ function updateChartTheme() {
             style: { color: textColor }
         },
         series: [{
-            color: '#4F46E5'
+            color: isDark ? '#22D3EE' : '#0891B2'
         }]
     }, false);
     chart.redraw();

--- a/historical.php
+++ b/historical.php
@@ -110,40 +110,42 @@ require_once 'layout.php';
 
 $displayName = ucwords(str_replace(['-', '_'], ' ', $key));
 $pageTitle = 'History: ' . $displayName . ($unit ? ' (' . $unit . ')' : '') . ' - Wheathampstead AstroPhotography Conditions';
-$heroTitle = $displayName . ' History';
+$heroTitle = $displayName . ' telemetry';
 $heroSubtitle = $unit
     ? 'Explore observatory records in ' . $unit . ' and focus on the ranges that matter most.'
     : 'Explore observatory records and focus on the ranges that matter most.';
-$heroAside = '<div class="flex flex-col items-start gap-2">'
-    . '<span class="text-xs font-semibold uppercase tracking-widest text-sky-700 dark:text-sky-300">Selected Topic</span>'
-    . '<span class="text-lg font-semibold text-slate-900 dark:text-slate-100">' . htmlspecialchars($displayName, ENT_QUOTES) . '</span>';
+$heroAside = '<div class="flex flex-col items-start gap-2 border-l border-cyan-300/30 pl-5">'
+    . '<span class="obs-data-label text-cyan-300">Selected channel</span>'
+    . '<span class="font-mono text-lg font-semibold text-white">' . htmlspecialchars($displayName, ENT_QUOTES) . '</span>';
 if ($unit) {
-    $heroAside .= '<span class="text-sm text-slate-600 dark:text-slate-400">Unit: ' . htmlspecialchars($unit, ENT_QUOTES) . '</span>';
+    $heroAside .= '<span class="text-sm text-slate-400">Unit · ' . htmlspecialchars($unit, ENT_QUOTES) . '</span>';
 }
 $heroAside .= '</div>';
 
-$navActions = '<a href="clear.php" class="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800">'
+$navActions = '<a href="clear.php" class="obs-nav-link">'
     . '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">'
     . '<path stroke-linecap="round" stroke-linejoin="round" d="M16.5 3.75h3.75v3.75M21 3 12.75 11.25" />'
     . '<path stroke-linecap="round" stroke-linejoin="round" d="M18.75 12v6a2.25 2.25 0 0 1-2.25 2.25h-9A2.25 2.25 0 0 1 5.25 18V9a2.25 2.25 0 0 1 2.25-2.25h6" />'
     . '</svg>'
-    . '<span>Monthly View</span>'
+    . '<span class="obs-nav-label">Monthly view</span>'
     . '</a>';
 
 layout_start($pageTitle, $heroTitle, $heroSubtitle, [
-    'extraHead' => '<script src="https://code.highcharts.com/stock/highstock.js"></script>',
+    'extraHead' => '<script src="https://code.highcharts.com/stock/highstock.js"></script>'
+        . '<script src="https://code.highcharts.com/modules/accessibility.js"></script>',
     'navActions' => $navActions,
     'heroAside' => $heroAside,
 ]);
 ?>
 <section>
-    <div class="space-y-6 border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+    <div class="obs-panel space-y-6">
         <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div class="space-y-1">
+                <p class="obs-data-label">ANL-01 · Signal history</p>
                 <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">Trend explorer</h2>
                 <p class="text-sm text-slate-600 dark:text-slate-400">Use the preset buttons or drag the timeline below to refine the range.</p>
             </div>
-            <button id="downloadCsv" type="button" class="inline-flex items-center gap-2 rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-sky-600 dark:hover:bg-sky-500">
+            <button id="downloadCsv" type="button" class="obs-button obs-button--primary">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 3.5-3.5M12 15l-3.5-3.5M5 21h14" />
                 </svg>
@@ -171,21 +173,21 @@ let data = [];
 
 function createButtonTheme(isDark) {
     return {
-        fill: isDark ? '#1F2937' : '#EEF2FF',
+        fill: isDark ? '#0B1324' : '#ECFEFF',
         stroke: 'transparent',
         style: {
-            color: isDark ? '#E5E7EB' : '#312E81',
+            color: isDark ? '#67E8F9' : '#0E7490',
             fontWeight: '600'
         },
         states: {
             hover: {
-                fill: isDark ? '#4338CA' : '#C7D2FE',
+                fill: isDark ? '#155E75' : '#CFFAFE',
                 style: {
-                    color: isDark ? '#E0E7FF' : '#312E81'
+                    color: isDark ? '#ECFEFF' : '#155E75'
                 }
             },
             select: {
-                fill: '#4F46E5',
+                fill: '#0891B2',
                 style: {
                     color: '#FFFFFF'
                 }
@@ -227,7 +229,7 @@ const histChart = Highcharts.stockChart('histChart', {
         inputBoxBackgroundColor: 'transparent'
     },
     navigator: {
-        maskFill: 'rgba(99, 102, 241, 0.2)',
+        maskFill: 'rgba(8, 145, 178, 0.2)',
         outlineColor: 'transparent'
     },
     scrollbar: { enabled: false },
@@ -239,7 +241,7 @@ const histChart = Highcharts.stockChart('histChart', {
     series: [{
         name: unit ? (topic + ' (' + unit + ')') : topic,
         data: [],
-        color: '#4F46E5',
+        color: '#0891B2',
         lineWidth: 2,
         tooltip: {
             valueSuffix: unit ? ' ' + unit : ''
@@ -265,7 +267,7 @@ loadData();
 function updateChartTheme() {
     const isDark = document.documentElement.classList.contains('dark');
     const textColor = isDark ? '#F9FAFB' : '#1F2937';
-    const gridColor = isDark ? '#374151' : '#E5E7EB';
+    const gridColor = isDark ? 'rgba(148, 163, 184, 0.14)' : 'rgba(15, 23, 42, 0.09)';
     histChart.update({
         chart: {
             resetZoomButton: {

--- a/index.php
+++ b/index.php
@@ -79,89 +79,120 @@ $last7SafeHoursDisplay = $last7SafeHours !== null ? number_format($last7SafeHour
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wheathampstead AstroPhotography Conditions</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="observatory.css">
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',
         }
+        try {
+            const storedTheme = localStorage.getItem('color-theme');
+            if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+            }
+        } catch (error) {}
     </script>
     <!-- Highcharts -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
 </head>
-<body class="min-h-screen bg-slate-100 text-slate-900 antialiased dark:bg-[#0b1120] dark:text-slate-100 font-sans">
-    <div class="max-w-7xl mx-auto px-5 py-6 sm:px-8 sm:py-8">
-        <header id="heroCard" class="mb-8 overflow-hidden border border-slate-800 bg-slate-950 text-white shadow-sm dark:border-slate-700">
-            <div class="border-b border-white/10 px-6 py-4 sm:px-8">
-                <div class="flex flex-wrap items-center justify-between gap-4">
-                    <a href="index.php" class="flex items-center gap-3 font-semibold tracking-tight text-white">
-                        <img src="logo.svg" alt="Observatory telescope logo" class="h-9 w-9" />
-                        <span class="text-sm sm:text-base">Wheathampstead AstroPhotography Conditions</span>
+<body class="observatory-shell antialiased">
+    <a href="#main-content" class="obs-skip-link">Skip to live observatory data</a>
+    <div class="obs-frame">
+        <header class="mb-8 space-y-4">
+            <div class="obs-topbar">
+                    <a href="index.php" class="obs-brand">
+                        <img src="logo.svg" alt="Observatory telescope logo" class="obs-brand-mark" />
+                        <span class="obs-brand-copy">
+                            <span class="obs-brand-kicker">WAC · Telemetry node</span>
+                            <span class="obs-brand-title">Wheathampstead Observatory</span>
+                        </span>
                     </a>
-                    <div class="flex items-center gap-3">
-                        <span id="mqttStatus" class="inline-flex items-center gap-2 rounded-md border border-amber-300/30 bg-amber-50/10 px-3 py-1.5 text-xs font-semibold text-amber-100">Connecting...</span>
-                        <button id="modeToggle" class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/15 text-slate-200 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300" aria-label="Switch to Dark Mode">
+                    <div class="obs-topbar-actions">
+                        <a href="clear.php" class="obs-nav-link"><span class="obs-nav-label">Sky archive</span><span aria-hidden="true">↗</span></a>
+                        <a href="HA.php" class="obs-nav-link"><span class="obs-nav-label">Wall display</span><span aria-hidden="true">▣</span></a>
+                        <span id="mqttStatus" class="obs-status-pill">Connecting</span>
+                        <button id="modeToggle" class="obs-icon-button" aria-label="Switch to Dark Mode">
                             <span aria-hidden="true">◐</span><span class="sr-only">Toggle colour mode</span>
                         </button>
                     </div>
-                </div>
             </div>
-            <div class="grid gap-8 px-6 py-9 sm:px-8 lg:grid-cols-[1fr_auto] lg:items-end">
+            <section id="heroCard" class="obs-hero">
+            <div class="obs-hero-grid">
                 <div>
-                    <p class="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-sky-300">Live observatory dashboard</p>
-                    <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-5xl">Know when the sky is ready.</h1>
-                    <p class="mt-4 max-w-2xl text-base leading-7 text-slate-300">A calm, focused view of current conditions, recent observations, and the roof camera — built for planning your next session.</p>
+                    <p class="obs-kicker mb-5 text-cyan-300">Live observatory intelligence · 51.81° N</p>
+                    <h1 class="obs-hero-title">Read the atmosphere.<br>Catch the clear window.</h1>
+                    <p class="obs-hero-copy">A live view of the sky above Wheathampstead—combining local weather instruments, roof-camera imagery, and historical observing conditions in one precise workspace.</p>
                 </div>
-                <div class="min-w-[15rem] border-l border-white/15 pl-5">
-                    <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">Safe observing · 7 days</p>
-                    <p class="mt-2 text-4xl font-semibold tracking-tight">
-                        <?= htmlspecialchars($last7SafeHoursDisplay, ENT_QUOTES, 'UTF-8'); ?><?php if ($last7SafeHours !== null): ?><span class="ml-1 text-base font-medium text-slate-400">hours</span><?php endif; ?>
+                <div class="obs-hero-metric">
+                    <p class="obs-data-label text-cyan-300">Clear-sky yield · Rolling 7d</p>
+                    <p class="obs-metric-value">
+                        <?= htmlspecialchars($last7SafeHoursDisplay, ENT_QUOTES, 'UTF-8'); ?><?php if ($last7SafeHours !== null): ?><span class="obs-metric-unit">hours</span><?php endif; ?>
                     </p>
-                    <a href="clear.php" class="mt-4 inline-flex text-sm font-semibold text-sky-300 transition hover:text-sky-200">Review monthly conditions <span class="ml-2" aria-hidden="true">→</span></a>
+                    <p class="mt-3 text-sm leading-6 text-slate-400">Accumulated time when local instruments reported safe observing conditions.</p>
+                    <a href="clear.php" class="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-cyan-300 transition hover:text-cyan-100">Open sky archive <span aria-hidden="true">→</span></a>
                 </div>
             </div>
+            <div class="obs-hero-footer" aria-label="Observatory system overview">
+                <div class="obs-hero-footer-item"><span class="obs-signal-dot obs-signal-dot--live"></span><span>Telemetry · MQTT stream</span></div>
+                <div class="obs-hero-footer-item"><span class="font-mono text-cyan-300">CAM-01</span><span>Roof all-sky camera</span></div>
+                <div class="obs-hero-footer-item"><span class="font-mono text-violet-300">UTC</span><span id="utcClock">Synchronising clock</span></div>
+            </div>
+            </section>
         </header>
-        <section class="mb-4 flex flex-wrap items-end justify-between gap-3">
-            <div><p class="text-xs font-semibold uppercase tracking-[0.18em] text-sky-700 dark:text-sky-300">Current conditions</p><h2 class="mt-1 text-xl font-semibold tracking-tight">Live instrument readings</h2></div>
-            <p class="text-sm text-slate-500 dark:text-slate-400">Values update as messages arrive.</p>
+        <main id="main-content">
+        <section class="obs-section-head">
+            <div><p class="obs-kicker">Atmospheric array · Live</p><h2 class="obs-section-title">Current instrument readings</h2></div>
+            <p class="obs-section-note"><span class="font-mono"><?= count($topics); ?> channels</span> · Values update as packets arrive</p>
         </section>
         <div id="cards" class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 auto-rows-fr"></div>
-        <div class="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1.2fr] lg:items-stretch">
-            <section id="skyImageContainer" class="relative flex flex-col overflow-hidden border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+        <div class="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-[1.08fr_1fr] lg:items-stretch">
+            <section id="skyImageContainer" class="obs-panel relative flex flex-col">
                 <div class="flex items-center justify-between gap-3">
-                    <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-100">Live Sky Camera</h2>
-                    <button type="button" data-target="skyImageContainer" class="fullscreen-toggle inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800" aria-label="Toggle full screen for sky image">
+                    <div><p class="obs-data-label">CAM-01 · Roof array</p><h2 class="mt-1 text-lg font-semibold">All-sky camera</h2></div>
+                    <button type="button" data-target="skyImageContainer" class="fullscreen-toggle obs-icon-button" aria-label="Toggle full screen for sky image">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8 3H5a2 2 0 0 0-2 2v3m0 8v3a2 2 0 0 0 2 2h3m8 0h3a2 2 0 0 0 2-2v-3m0-8V5a2 2 0 0 0-2-2h-3" />
                         </svg>
                     </button>
                 </div>
-                <div class="mt-4 flex flex-1 items-center justify-center overflow-hidden rounded-lg bg-slate-950 p-2 shadow-inner dark:bg-slate-900 min-h-[18rem]">
-                    <img id="skyImage" alt="Sky image" class="max-h-full w-full object-contain" />
-                </div>
-                <p class="mt-4 text-sm text-gray-600 dark:text-gray-300">Updated continuously from the observatory roof camera.</p>
-            </section>
-            <section id="chartHub" class="relative flex flex-col overflow-hidden border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
-                <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div role="tablist" aria-label="Chart selection" class="inline-flex rounded-md border border-slate-200 bg-slate-100 p-1 text-sm font-semibold text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                        <button type="button" data-chart-tab="safe" class="chart-tab rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 dark:focus-visible:ring-indigo-400" role="tab" aria-selected="true">Safe Hours</button>
-                        <button type="button" data-chart-tab="realtime" class="chart-tab rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 dark:focus-visible:ring-indigo-400" role="tab" aria-selected="false">Realtime Trends</button>
+                <div class="obs-camera-well mt-4 flex flex-1 items-center justify-center p-2">
+                    <div id="skyImagePlaceholder" class="obs-camera-placeholder" aria-live="polite">
+                        <span class="obs-reticle" aria-hidden="true"></span>
+                        <span class="obs-data-label text-slate-500">Awaiting next camera frame</span>
                     </div>
-                    <button type="button" data-target="chartHub" class="fullscreen-toggle inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800" aria-label="Toggle full screen for charts">
+                    <img id="skyImage" alt="Latest image from the observatory roof camera" class="relative z-10 max-h-full w-full object-contain" />
+                </div>
+                <div class="mt-4 flex items-center justify-between gap-3 text-xs text-slate-500 dark:text-slate-400"><span>Updated continuously via MQTT</span><span class="font-mono uppercase tracking-wider">JPEG · LIVE</span></div>
+            </section>
+            <section id="chartHub" class="obs-panel relative flex flex-col">
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <p class="obs-data-label">ANL-02 · Signal analysis</p>
+                        <div role="tablist" aria-label="Chart selection" class="obs-segmented mt-2">
+                        <button type="button" data-chart-tab="safe" class="chart-tab obs-tab" role="tab" aria-selected="true">Clear-sky history</button>
+                        <button type="button" data-chart-tab="realtime" class="chart-tab obs-tab" role="tab" aria-selected="false">Live environment</button>
+                        </div>
+                    </div>
+                    <button type="button" data-target="chartHub" class="fullscreen-toggle obs-icon-button" aria-label="Toggle full screen for charts">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8 3H5a2 2 0 0 0-2 2v3m0 8v3a2 2 0 0 0 2 2h3m8 0h3a2 2 0 0 0 2-2v-3m0-8V5a2 2 0 0 0-2-2h-3" />
                         </svg>
                     </button>
                 </div>
-                <div id="chartDisplay" class="relative mt-4 flex-1 overflow-hidden rounded-lg bg-slate-50 p-2 dark:bg-slate-900/60 min-h-[18rem]">
+                <div id="chartDisplay" class="obs-chart-well relative mt-4 flex-1 p-2 min-h-[22rem]">
                     <div id="safeChart" class="absolute inset-0"></div>
                     <div id="envChart" class="absolute inset-0 hidden"></div>
                 </div>
-                <p class="mt-4 text-sm text-gray-600 dark:text-gray-300">
-                    Compare long-term safe observing hours with live sensor readings using the tabs above.
-                </p>
+                <p class="mt-4 text-xs leading-5 text-slate-500 dark:text-slate-400">Thirty-day observing conditions and live environmental signals share a common analysis surface.</p>
             </section>
         </div>
+        </main>
+        <footer class="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-slate-400/20 py-6 text-xs text-slate-500 dark:text-slate-500">
+            <span class="font-mono uppercase tracking-[0.15em]">WAC · Wheathampstead, UK</span>
+            <span>Local instruments · Local sky intelligence</span>
+        </footer>
     </div>
 
     <script>
@@ -187,19 +218,11 @@ const envSeriesData = envTopicNames.map(() => []);
 let envChart = null;
 
     const heroCard = document.getElementById('heroCard');
-    const heroDefaultGradientClasses = ['bg-slate-950', 'dark:bg-slate-950'];
-    const heroSafeGradientClasses = ['bg-emerald-950', 'dark:bg-emerald-950'];
     let heroState = 'default';
 
     function setHeroGradient(state) {
         if (!heroCard || state === heroState) return;
-        if (state === 'safe') {
-            heroCard.classList.remove(...heroDefaultGradientClasses);
-            heroCard.classList.add(...heroSafeGradientClasses);
-        } else {
-            heroCard.classList.remove(...heroSafeGradientClasses);
-            heroCard.classList.add(...heroDefaultGradientClasses);
-        }
+        heroCard.classList.toggle('obs-hero--safe', state === 'safe');
         heroState = state;
     }
 
@@ -222,6 +245,9 @@ let envChart = null;
     const cardsContainer = document.getElementById('cards');
     cardsContainer.innerHTML = '';
     const sanitize = name => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const escapeHtml = value => String(value).replace(/[&<>'"]/g, character => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#039;', '"': '&quot;'
+    })[character]);
 
     const icons = {
         temperature: 'TMP',
@@ -234,7 +260,7 @@ let envChart = null;
         dewpoint: 'DPT'
     };
 
-    const statusBaseClasses = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-sm ring-1 ring-inset transition-colors backdrop-blur-sm';
+    const statusBaseClasses = 'inline-flex items-center rounded-full border px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] transition-colors';
 
     const miniChartData = {};
     const miniCharts = {};
@@ -255,15 +281,15 @@ let envChart = null;
         const isDark = document.documentElement.classList.contains('dark');
         if (isDark) {
             return {
-                line: 'rgba(165, 180, 252, 0.9)',
-                fillTop: 'rgba(129, 140, 248, 0.35)',
-                fillBottom: 'rgba(129, 140, 248, 0.05)'
+                line: 'rgba(103, 232, 249, 0.95)',
+                fillTop: 'rgba(34, 211, 238, 0.28)',
+                fillBottom: 'rgba(34, 211, 238, 0.02)'
             };
         }
         return {
-            line: 'rgba(79, 70, 229, 0.9)',
-            fillTop: 'rgba(129, 140, 248, 0.25)',
-            fillBottom: 'rgba(99, 102, 241, 0.04)'
+            line: 'rgba(8, 145, 178, 0.95)',
+            fillTop: 'rgba(6, 182, 212, 0.2)',
+            fillBottom: 'rgba(6, 182, 212, 0.02)'
         };
     }
 
@@ -272,7 +298,7 @@ let envChart = null;
         const palette = getMiniChartPalette();
         const isDark = document.documentElement.classList.contains('dark');
         const textColor = isDark ? '#F9FAFB' : '#1F2937';
-        const tooltipBg = isDark ? '#111827' : '#EEF2FF';
+        const tooltipBg = isDark ? '#0B1324' : '#FFFFFF';
         chart.update({
 
             chart: { backgroundColor: 'transparent', plotBackgroundColor: 'transparent' },
@@ -397,37 +423,37 @@ let envChart = null;
         const card = document.createElement('div');
 
         card.id = 'card-' + sanitize(name);
-        card.className = 'relative flex h-full flex-col overflow-hidden border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-950';
+        card.className = 'obs-readout-card flex h-full flex-col';
         const icon = icons[name] || 'SEN';
-        const label = name.replace(/[_-]/g, ' ');
-        const unitMarkup = cfg.unit ? `<span class="ml-1 text-lg font-medium text-slate-500 dark:text-slate-300">${cfg.unit}</span>` : '';
+        const label = escapeHtml(name.replace(/[_-]/g, ' '));
+        const unitMarkup = cfg.unit ? `<span class="obs-readout-unit">${escapeHtml(cfg.unit)}</span>` : '';
         card.innerHTML = `
             <div class="relative flex h-full flex-col justify-between gap-5">
                 <div class="flex flex-wrap items-start justify-between gap-3">
                     <div class="flex items-center gap-3">
-                        <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-sky-50 text-[10px] font-bold tracking-wide text-sky-700 dark:bg-sky-950 dark:text-sky-300"><span>${icon}</span></div>
+                        <div class="obs-instrument-mark"><span class="obs-instrument-code">${icon}</span></div>
                         <div class="flex flex-col">
-                            <h2 class="text-base font-semibold capitalize text-slate-900 dark:text-slate-100">${label}</h2>
-                            <p class="text-[11px] font-medium uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">Live sensor</p>
+                            <h3 class="text-base font-semibold capitalize text-slate-900 dark:text-slate-100">${label}</h3>
+                            <p class="obs-data-label mt-1">Instrument channel</p>
                         </div>
                     </div>
-                    <span id="status-${sanitize(name)}" class="${statusBaseClasses} bg-slate-100/80 text-slate-600 ring-slate-200/70">Monitoring</span>
+                    <span id="status-${sanitize(name)}" class="${statusBaseClasses} border-slate-300/60 bg-slate-500/5 text-slate-500 dark:border-slate-700 dark:text-slate-400">Awaiting</span>
                 </div>
                 <div class="flex flex-col gap-4">
-                    <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                        <p class="text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">
+                    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                        <p class="obs-readout-value text-slate-900 dark:text-white">
                             <span id="${id}">--</span>${unitMarkup}
                         </p>
-                        <div class="relative h-24 w-full overflow-hidden rounded-md bg-slate-50 ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800 sm:h-28 sm:w-auto sm:min-w-[10rem]">
+                        <div class="obs-chart-well relative h-24 w-full sm:h-28 sm:w-auto sm:min-w-[10rem]">
                             <div id="chart-${sanitize(name)}" class="absolute inset-0"></div>
                         </div>
                     </div>
                     <div class="flex flex-wrap items-center gap-2">
-                        <a href="historical.php?topic=${encodeURIComponent(name)}" class="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800" aria-label="View History">
+                        <a href="historical.php?topic=${encodeURIComponent(name)}" class="obs-button" aria-label="View ${label} history">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18M6 15l4-4 3 3 7-7" />
                             </svg>
-                            View History
+                            Open history
                         </a>
                     </div>
                 </div>
@@ -443,14 +469,14 @@ let envChart = null;
     let client;
     let connectAttempts = 0;
 
-    function updateStatus(text, cls) {
+    function updateStatus(text, state = 'warn') {
         statusEl.textContent = text;
-        statusEl.className = 'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold shadow-sm ring-1 ring-white/50 backdrop-blur ' + cls;
+        statusEl.className = `obs-status-pill obs-status-pill--${state}`;
     }
 
     function scheduleReconnect() {
         const delay = Math.min(1000 * Math.pow(2, connectAttempts), 30000);
-        updateStatus('Reconnecting...', 'bg-amber-100/90 text-amber-800');
+        updateStatus('MQTT · Reconnecting', 'warn');
         setTimeout(() => {
             connectAttempts++;
             connectClient();
@@ -460,7 +486,7 @@ let envChart = null;
     function connectClient() {
         if (!window.mqtt) {
             console.warn('MQTT.js library is not loaded');
-            updateStatus('MQTT unavailable', 'bg-red-100 text-red-700');
+            updateStatus('MQTT · Unavailable', 'bad');
             return;
         }
         const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -475,15 +501,17 @@ let envChart = null;
 
     function onConnectionLost() {
         console.log('Connection lost');
-        updateStatus('Disconnected', 'bg-red-100 text-red-700');
+        updateStatus('MQTT · Disconnected', 'bad');
         scheduleReconnect();
     }
     function onMessageArrived(topic, message) {
         if (topic === 'Observatory/skyimage') {
             const img = document.getElementById('skyImage');
+            const placeholder = document.getElementById('skyImagePlaceholder');
             if (skyImageUrl) URL.revokeObjectURL(skyImageUrl);
             const blob = new Blob([message], { type: 'image/jpeg' });
             skyImageUrl = URL.createObjectURL(blob);
+            img.onload = () => { if (placeholder) placeholder.hidden = true; };
             img.src = skyImageUrl;
             return;
         }
@@ -517,10 +545,10 @@ let envChart = null;
                 if (statusEl) {
                     if (match) {
                         statusEl.textContent = 'Favorable';
-                        statusEl.className = `${statusBaseClasses} bg-emerald-100/90 text-emerald-700 ring-emerald-300/60`;
+                        statusEl.className = `${statusBaseClasses} border-emerald-400/30 bg-emerald-400/10 text-emerald-600 dark:text-emerald-300`;
                     } else {
                         statusEl.textContent = 'Warning';
-                        statusEl.className = `${statusBaseClasses} bg-rose-100/90 text-rose-700 ring-rose-300/60`;
+                        statusEl.className = `${statusBaseClasses} border-rose-400/30 bg-rose-400/10 text-rose-600 dark:text-rose-300`;
                     }
                 }
 
@@ -529,8 +557,8 @@ let envChart = null;
                 }
             } else {
                 if (statusEl) {
-                    statusEl.textContent = 'Monitoring';
-                    statusEl.className = `${statusBaseClasses} bg-slate-100/80 text-slate-600 ring-slate-200/70`;
+                    statusEl.textContent = 'Live';
+                    statusEl.className = `${statusBaseClasses} border-cyan-400/25 bg-cyan-400/5 text-cyan-700 dark:text-cyan-300`;
                 }
                 if (isTrackedSensor) {
                     sensorStatus.set(name, 'unknown');
@@ -560,7 +588,7 @@ let envChart = null;
         }
     }
     function onConnect() {
-        updateStatus('Connected', 'bg-emerald-100 text-emerald-700');
+        updateStatus('MQTT · Connected', 'ok');
         connectAttempts = 0;
         Object.values(topics).forEach(cfg => client.subscribe(cfg.topic));
         client.subscribe('Observatory/skyimage');
@@ -569,7 +597,7 @@ let envChart = null;
     function loadMQTT(urls, idx = 0) {
         if (idx >= urls.length) {
             console.warn('MQTT.js library failed to load');
-            updateStatus('MQTT unavailable', 'bg-red-100 text-red-700');
+            updateStatus('MQTT · Unavailable', 'bad');
             return;
         }
         const script = document.createElement('script');
@@ -591,16 +619,27 @@ let envChart = null;
             type: 'column',
             backgroundColor: 'transparent',
             plotBackgroundColor: 'transparent',
+            spacing: [22, 16, 12, 12],
             zooming: {
                 type: 'x',
                 mouseWheel: true
             },
             zoomType: 'x'
         },
-        title: { text: 'Observable Hours (Last 30 Days)' },
+        title: { text: 'Observable window · last 30 days', align: 'left' },
+        subtitle: { text: 'Hours reported safe by the local sensor array', align: 'left' },
+        credits: { enabled: false },
+        legend: { enabled: false },
         xAxis: { categories: safeCategories },
         yAxis: { title: { text: 'Hours' } },
-        series: [{ name: 'Hours', data: safeHours }]
+        plotOptions: {
+            column: {
+                borderWidth: 0,
+                borderRadius: 3,
+                color: '#0891b2'
+            }
+        },
+        series: [{ name: 'Safe hours', data: safeHours }]
     });
 
     function ensureEnvChart() {
@@ -616,9 +655,12 @@ let envChart = null;
                 },
                 zoomType: 'x'
             },
-            title: { text: 'Realtime Clouds, Light, SQM' },
+            title: { text: 'Live atmospheric signals', align: 'left' },
+            subtitle: { text: 'Cloud temperature, ambient light and sky quality', align: 'left' },
+            credits: { enabled: false },
             xAxis: { type: 'datetime' },
-            series: envSeriesLabels.map((name, idx) => ({ name, data: envSeriesData[idx].slice() }))
+            colors: ['#22d3ee', '#a78bfa', '#34d399'],
+            series: envSeriesLabels.map((name, idx) => ({ name, data: envSeriesData[idx].slice(), lineWidth: 2 }))
         });
         updateChartsTheme();
         return envChart;
@@ -628,15 +670,11 @@ let envChart = null;
     const safeChartContainer = document.getElementById('safeChart');
     const envChartContainer = document.getElementById('envChart');
     let activeChartTab = null;
-    const activeTabClasses = ['bg-white', 'text-indigo-700', 'shadow', 'dark:bg-gray-800', 'dark:text-indigo-100'];
-    const inactiveTabClasses = ['text-indigo-500', 'hover:text-indigo-700', 'dark:text-indigo-200', 'dark:hover:text-indigo-100'];
 
     function applyTabState(tab) {
         chartTabs.forEach(btn => {
             const isActive = btn.dataset.chartTab === tab;
             btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
-            activeTabClasses.forEach(cls => btn.classList.toggle(cls, isActive));
-            inactiveTabClasses.forEach(cls => btn.classList.toggle(cls, !isActive));
         });
     }
 
@@ -696,8 +734,8 @@ let envChart = null;
             const isActive = target && document.fullscreenElement === target;
             btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
             btn.classList.toggle('ring-4', isActive);
-            btn.classList.toggle('ring-indigo-200', isActive);
-            btn.classList.toggle('dark:ring-indigo-400', isActive);
+            btn.classList.toggle('ring-cyan-200', isActive);
+            btn.classList.toggle('dark:ring-cyan-400', isActive);
             btn.classList.toggle('shadow-lg', isActive);
         });
         requestAnimationFrame(() => {
@@ -714,7 +752,8 @@ let envChart = null;
     function updateChartsTheme() {
         const isDark = document.documentElement.classList.contains('dark');
         const textColor = isDark ? '#F9FAFB' : '#1F2937';
-        const gridColor = isDark ? '#374151' : '#e5e7eb';
+        const gridColor = isDark ? 'rgba(148, 163, 184, 0.14)' : 'rgba(15, 23, 42, 0.09)';
+        const mutedColor = isDark ? '#91A2B8' : '#64748B';
         const charts = [safeChart];
         if (envChart) charts.push(envChart);
         charts.forEach(c => {
@@ -732,7 +771,8 @@ let envChart = null;
                     plotBackgroundColor: 'transparent',
                     resetZoomButton: { theme: resetZoomTheme }
                 },
-                title: { style: { color: textColor } },
+                title: { style: { color: textColor, fontSize: '15px', fontWeight: '650' } },
+                subtitle: { style: { color: mutedColor, fontSize: '11px' } },
                 xAxis: { labels: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
                 yAxis: { labels: { style: { color: textColor } }, title: { style: { color: textColor } }, gridLineColor: gridColor, lineColor: textColor },
                 legend: { itemStyle: { color: textColor } }
@@ -750,9 +790,20 @@ let envChart = null;
 
     modeToggle.addEventListener('click', () => {
         document.documentElement.classList.toggle('dark');
+        localStorage.setItem('color-theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
         updateModeIcon();
         updateChartsTheme();
     });
+
+    const utcClock = document.getElementById('utcClock');
+    function updateUtcClock() {
+        if (!utcClock) return;
+        utcClock.textContent = new Intl.DateTimeFormat('en-GB', {
+            timeZone: 'UTC', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+        }).format(new Date()) + ' · System clock';
+    }
+    updateUtcClock();
+    window.setInterval(updateUtcClock, 1000);
 
     updateModeIcon();
     updateChartsTheme();

--- a/layout.php
+++ b/layout.php
@@ -12,28 +12,38 @@ function layout_start(string $pageTitle, string $heroTitle, string $heroSubtitle
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($pageTitle); ?></title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="observatory.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',
         };
+        try {
+            const storedTheme = localStorage.getItem('color-theme');
+            if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+            }
+        } catch (error) {}
     </script>
     <?php echo $extraHead; ?>
 </head>
-<body class="min-h-screen bg-slate-100 text-slate-900 antialiased dark:bg-[#0b1120] dark:text-slate-100 font-sans">
-    <div class="min-h-screen">
-        <div class="max-w-7xl mx-auto px-5 py-6 sm:px-8 sm:py-8">
-            <header class="space-y-5 mb-8">
-                <div class="flex flex-wrap items-center justify-between gap-4 border border-slate-200 bg-white px-5 py-4 shadow-sm dark:border-slate-800 dark:bg-slate-950">
-                    <a href="index.php" class="flex items-center gap-3 text-slate-900 dark:text-slate-100 font-semibold hover:text-sky-700 dark:hover:text-sky-300 transition">
-                        <img src="logo.svg" alt="Observatory telescope logo" class="w-9 h-9">
-                        <span class="text-sm tracking-tight">Wheathampstead AstroPhotography Conditions</span>
+<body class="observatory-shell antialiased">
+    <a href="#main-content" class="obs-skip-link">Skip to observatory data</a>
+    <div class="obs-frame">
+            <header class="space-y-4 mb-8">
+                <div class="obs-topbar">
+                    <a href="index.php" class="obs-brand">
+                        <img src="logo.svg" alt="Observatory telescope logo" class="obs-brand-mark">
+                        <span class="obs-brand-copy">
+                            <span class="obs-brand-kicker">WAC · Telemetry node</span>
+                            <span class="obs-brand-title">Wheathampstead Observatory</span>
+                        </span>
                     </a>
-                    <div class="flex items-center gap-3">
+                    <div class="obs-topbar-actions">
                         <?php if ($navActions): ?>
                             <?php echo $navActions; ?>
                         <?php endif; ?>
-                        <button id="modeToggle" type="button" class="inline-flex items-center justify-center w-11 h-11 rounded-md border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800 transition" aria-live="polite">
+                        <button id="modeToggle" type="button" class="obs-icon-button" aria-live="polite">
                             <span class="sr-only" id="modeToggleLabel">Toggle dark mode</span>
                             <svg id="modeIconSun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-5 w-5 hidden" fill="currentColor">
                                 <path d="M12 4.75a.75.75 0 0 0 .75-.75V2a.75.75 0 0 0-1.5 0v2a.75.75 0 0 0 .75.75Zm5.25 7.25a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0ZM4.75 12a.75.75 0 0 0-.75-.75H2a.75.75 0 0 0 0 1.5h2a.75.75 0 0 0 .75-.75Zm18 0a.75.75 0 0 0-.75-.75h-2a.75.75 0 0 0 0 1.5h2a.75.75 0 0 0 .75-.75ZM7.11 6.46a.75.75 0 0 0 0-1.06L5.7 4a.75.75 0 0 0-1.06 1.06l1.41 1.4a.75.75 0 0 0 1.06 0Zm12.25-.53 1.4-1.4A.75.75 0 1 0 19.7 3.47l-1.4 1.4a.75.75 0 1 0 1.06 1.06ZM12 19.25a.75.75 0 0 0-.75.75v2a.75.75 0 0 0 1.5 0v-2a.75.75 0 0 0-.75-.75Zm6.89-1.71a.75.75 0 0 0-1.06 0l-1.4 1.4a.75.75 0 0 0 1.06 1.06l1.4-1.4a.75.75 0 0 0 0-1.06ZM5.7 19.7a.75.75 0 1 0 1.06-1.06l-1.4-1.4a.75.75 0 0 0-1.06 1.06l1.4 1.4Z" />
@@ -44,24 +54,24 @@ function layout_start(string $pageTitle, string $heroTitle, string $heroSubtitle
                         </button>
                     </div>
                 </div>
-                <div class="border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950 sm:p-8">
+                <div class="obs-page-hero">
                     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
                         <div class="space-y-3">
-                            <p class="text-sm font-semibold uppercase tracking-widest text-sky-700 dark:text-sky-300">Observatory Insights</p>
-                            <h1 class="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white"><?php echo htmlspecialchars($heroTitle); ?></h1>
+                            <p class="obs-kicker text-cyan-300">Observatory archive · Mission data</p>
+                            <h1 class="text-3xl sm:text-4xl font-semibold tracking-tight text-white"><?php echo htmlspecialchars($heroTitle); ?></h1>
                             <?php if ($heroSubtitle !== ''): ?>
-                                <p class="max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300"><?php echo htmlspecialchars($heroSubtitle); ?></p>
+                                <p class="max-w-2xl text-base leading-7 text-slate-300"><?php echo htmlspecialchars($heroSubtitle); ?></p>
                             <?php endif; ?>
                         </div>
                         <?php if ($heroAside): ?>
-                            <div class="flex-shrink-0 text-sm text-slate-600 dark:text-slate-300">
+                            <div class="flex-shrink-0 text-sm text-slate-300">
                                 <?php echo $heroAside; ?>
                             </div>
                         <?php endif; ?>
                     </div>
                 </div>
             </header>
-            <main class="space-y-10">
+            <main id="main-content" class="space-y-8">
 <?php
 }
 
@@ -69,7 +79,10 @@ function layout_end(string $extraScripts = ''): void
 {
     ?>
             </main>
-        </div>
+            <footer class="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-slate-400/20 py-6 text-xs text-slate-500 dark:text-slate-500">
+                <span class="font-mono uppercase tracking-[0.15em]">WAC · Wheathampstead, UK</span>
+                <span>Local observatory telemetry and sky-condition archive</span>
+            </footer>
     </div>
     <script>
         (function() {

--- a/observatory.css
+++ b/observatory.css
@@ -1,0 +1,743 @@
+:root {
+    color-scheme: light;
+    --obs-canvas: #edf3f8;
+    --obs-canvas-deep: #dfe9f2;
+    --obs-panel: rgba(255, 255, 255, 0.86);
+    --obs-panel-strong: #ffffff;
+    --obs-panel-soft: rgba(241, 247, 251, 0.88);
+    --obs-border: rgba(15, 23, 42, 0.12);
+    --obs-border-strong: rgba(14, 116, 144, 0.28);
+    --obs-text: #0b1425;
+    --obs-muted: #526176;
+    --obs-faint: #758399;
+    --obs-cyan: #0891b2;
+    --obs-cyan-bright: #22d3ee;
+    --obs-violet: #6d5ce7;
+    --obs-green: #059669;
+    --obs-red: #e11d48;
+    --obs-shadow: 0 24px 65px rgba(15, 23, 42, 0.09);
+    --obs-grid: rgba(15, 23, 42, 0.045);
+}
+
+html.dark {
+    color-scheme: dark;
+    --obs-canvas: #050914;
+    --obs-canvas-deep: #080e1c;
+    --obs-panel: rgba(10, 17, 32, 0.84);
+    --obs-panel-strong: #0b1324;
+    --obs-panel-soft: rgba(14, 25, 45, 0.78);
+    --obs-border: rgba(148, 163, 184, 0.16);
+    --obs-border-strong: rgba(34, 211, 238, 0.28);
+    --obs-text: #edf7ff;
+    --obs-muted: #a8b8cc;
+    --obs-faint: #70829a;
+    --obs-cyan: #22d3ee;
+    --obs-cyan-bright: #67e8f9;
+    --obs-violet: #a78bfa;
+    --obs-green: #34d399;
+    --obs-red: #fb7185;
+    --obs-shadow: 0 30px 80px rgba(0, 0, 0, 0.32);
+    --obs-grid: rgba(125, 211, 252, 0.045);
+}
+
+html {
+    background: var(--obs-canvas);
+    scroll-behavior: smooth;
+}
+
+body.observatory-shell {
+    position: relative;
+    isolation: isolate;
+    min-height: 100vh;
+    margin: 0;
+    overflow-x: hidden;
+    background:
+        radial-gradient(circle at 12% -8%, rgba(14, 165, 233, 0.14), transparent 27rem),
+        radial-gradient(circle at 92% 12%, rgba(124, 58, 237, 0.11), transparent 31rem),
+        linear-gradient(180deg, var(--obs-canvas) 0%, var(--obs-canvas-deep) 100%);
+    color: var(--obs-text);
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body.observatory-shell::before,
+body.observatory-shell::after {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    content: "";
+}
+
+body.observatory-shell::before {
+    opacity: 0.22;
+    background-image:
+        radial-gradient(circle at 17% 18%, rgba(255,255,255,.95) 0 0.7px, transparent 0.9px),
+        radial-gradient(circle at 68% 9%, rgba(255,255,255,.78) 0 0.6px, transparent 0.9px),
+        radial-gradient(circle at 88% 42%, rgba(255,255,255,.74) 0 0.8px, transparent 1px),
+        radial-gradient(circle at 40% 72%, rgba(255,255,255,.68) 0 0.6px, transparent 0.9px);
+    background-size: 270px 270px, 340px 340px, 420px 420px, 310px 310px;
+}
+
+html.dark body.observatory-shell::before {
+    opacity: 0.55;
+}
+
+body.observatory-shell::after {
+    opacity: 0.7;
+    background-image:
+        linear-gradient(var(--obs-grid) 1px, transparent 1px),
+        linear-gradient(90deg, var(--obs-grid) 1px, transparent 1px);
+    background-size: 64px 64px;
+    mask-image: linear-gradient(to bottom, black, transparent 82%);
+}
+
+::selection {
+    background: rgba(34, 211, 238, 0.28);
+    color: var(--obs-text);
+}
+
+.obs-skip-link {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 100;
+    transform: translateY(-180%);
+    border-radius: 0.5rem;
+    background: #ffffff;
+    padding: 0.75rem 1rem;
+    color: #07111f;
+    font-weight: 700;
+    box-shadow: 0 10px 30px rgba(0,0,0,.25);
+    transition: transform 160ms ease;
+}
+
+.obs-skip-link:focus {
+    transform: translateY(0);
+}
+
+.obs-frame {
+    position: relative;
+    z-index: 1;
+    width: min(100% - 2rem, 88rem);
+    margin-inline: auto;
+    padding-block: 1rem 3rem;
+}
+
+.obs-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 4.5rem;
+    border: 1px solid var(--obs-border);
+    border-radius: 1rem;
+    background: var(--obs-panel);
+    padding: 0.8rem 1rem;
+    box-shadow: 0 12px 40px rgba(2, 8, 23, 0.08);
+    backdrop-filter: blur(20px);
+}
+
+.obs-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.8rem;
+    min-width: 0;
+    color: var(--obs-text);
+    text-decoration: none;
+}
+
+.obs-brand-mark {
+    width: 2.75rem;
+    height: 2.75rem;
+    flex: 0 0 auto;
+    filter: drop-shadow(0 0 16px rgba(34, 211, 238, 0.2));
+}
+
+.obs-brand-copy {
+    display: grid;
+    gap: 0.08rem;
+    min-width: 0;
+}
+
+.obs-brand-title {
+    overflow: hidden;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.obs-brand-kicker,
+.obs-kicker,
+.obs-data-label {
+    color: var(--obs-cyan);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    line-height: 1.4;
+    text-transform: uppercase;
+}
+
+.obs-topbar-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.55rem;
+}
+
+.obs-nav-link,
+.obs-icon-button,
+.obs-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 2.5rem;
+    border: 1px solid var(--obs-border);
+    border-radius: 0.65rem;
+    background: var(--obs-panel-soft);
+    color: var(--obs-text);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+    transition: border-color 160ms ease, background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.obs-nav-link,
+.obs-button {
+    padding: 0.72rem 0.95rem;
+}
+
+.obs-icon-button {
+    width: 2.5rem;
+    padding: 0;
+}
+
+.obs-nav-link:hover,
+.obs-icon-button:hover,
+.obs-button:hover {
+    border-color: var(--obs-border-strong);
+    background: rgba(34, 211, 238, 0.08);
+    color: var(--obs-cyan);
+}
+
+.obs-nav-link:focus-visible,
+.obs-icon-button:focus-visible,
+.obs-button:focus-visible,
+.obs-tab:focus-visible {
+    outline: 2px solid var(--obs-cyan-bright);
+    outline-offset: 3px;
+}
+
+.obs-button--primary {
+    border-color: transparent;
+    background: linear-gradient(135deg, #0e7490, #2563eb);
+    color: #ffffff;
+    box-shadow: 0 10px 25px rgba(14, 116, 144, 0.2);
+}
+
+.obs-button--primary:hover {
+    border-color: transparent;
+    background: linear-gradient(135deg, #0891b2, #4f46e5);
+    color: #ffffff;
+    transform: translateY(-1px);
+}
+
+.obs-select {
+    min-height: 2.6rem;
+    border: 1px solid var(--obs-border);
+    border-radius: 0.65rem;
+    background: var(--obs-panel-strong);
+    padding: 0.55rem 2.3rem 0.55rem 0.75rem;
+    color: var(--obs-text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.obs-select:focus {
+    border-color: var(--obs-cyan);
+    outline: 2px solid rgba(34, 211, 238, 0.18);
+    outline-offset: 2px;
+}
+
+.obs-hero {
+    position: relative;
+    overflow: hidden;
+    min-height: 27rem;
+    border: 1px solid rgba(103, 232, 249, 0.2);
+    border-radius: 1.35rem;
+    background:
+        radial-gradient(circle at 78% 10%, rgba(67, 56, 202, 0.34), transparent 25rem),
+        radial-gradient(circle at 15% 105%, rgba(8, 145, 178, 0.25), transparent 28rem),
+        linear-gradient(135deg, #07101f 0%, #0a1428 55%, #090d1c 100%);
+    color: #f8fafc;
+    box-shadow: 0 35px 85px rgba(2, 6, 23, 0.28);
+}
+
+.obs-hero::before {
+    position: absolute;
+    inset: 0;
+    content: "";
+    opacity: 0.42;
+    background-image:
+        linear-gradient(rgba(103, 232, 249, 0.05) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(103, 232, 249, 0.05) 1px, transparent 1px);
+    background-size: 56px 56px;
+    mask-image: linear-gradient(100deg, black, transparent 70%);
+}
+
+.obs-hero::after {
+    position: absolute;
+    top: -13rem;
+    right: -8rem;
+    width: 38rem;
+    height: 38rem;
+    border: 1px solid rgba(103, 232, 249, 0.18);
+    border-radius: 50%;
+    box-shadow:
+        0 0 0 5rem rgba(103, 232, 249, 0.018),
+        0 0 0 9rem rgba(129, 140, 248, 0.018),
+        inset 0 0 75px rgba(56, 189, 248, 0.08);
+    content: "";
+}
+
+.obs-hero--safe {
+    border-color: rgba(52, 211, 153, 0.3);
+    background:
+        radial-gradient(circle at 78% 10%, rgba(5, 150, 105, 0.28), transparent 25rem),
+        radial-gradient(circle at 15% 105%, rgba(8, 145, 178, 0.22), transparent 28rem),
+        linear-gradient(135deg, #06131a 0%, #08221f 55%, #07131d 100%);
+}
+
+.obs-hero-grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    min-height: 23rem;
+    grid-template-columns: minmax(0, 1.45fr) minmax(17rem, 0.55fr);
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(2rem, 5vw, 4.5rem);
+}
+
+.obs-hero-title {
+    max-width: 54rem;
+    margin: 0;
+    font-size: clamp(2.6rem, 6vw, 5.2rem);
+    font-weight: 650;
+    letter-spacing: -0.055em;
+    line-height: 0.98;
+}
+
+.obs-hero-copy {
+    max-width: 42rem;
+    margin: 1.5rem 0 0;
+    color: #b8c7da;
+    font-size: clamp(1rem, 1.5vw, 1.15rem);
+    line-height: 1.75;
+}
+
+.obs-hero-metric {
+    position: relative;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 1rem;
+    background: rgba(7, 14, 29, 0.58);
+    padding: 1.4rem;
+    backdrop-filter: blur(18px);
+}
+
+.obs-hero-metric::before {
+    position: absolute;
+    top: -1px;
+    left: 1.3rem;
+    width: 4rem;
+    height: 1px;
+    background: var(--obs-cyan-bright);
+    box-shadow: 0 0 14px rgba(34, 211, 238, 0.7);
+    content: "";
+}
+
+.obs-metric-value {
+    margin: 0.7rem 0 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: clamp(2.8rem, 5vw, 4.4rem);
+    font-weight: 600;
+    letter-spacing: -0.07em;
+    line-height: 1;
+}
+
+.obs-metric-unit {
+    margin-left: 0.35rem;
+    color: #8495ac;
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.9rem;
+    font-weight: 650;
+    letter-spacing: 0;
+}
+
+.obs-hero-footer {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+    background: rgba(2, 8, 23, 0.28);
+}
+
+.obs-hero-footer-item {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    min-height: 4.15rem;
+    padding: 0.8rem clamp(1rem, 3vw, 2rem);
+    color: #aab9cb;
+    font-size: 0.76rem;
+    font-weight: 650;
+}
+
+.obs-hero-footer-item + .obs-hero-footer-item {
+    border-left: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.obs-signal-dot {
+    width: 0.46rem;
+    height: 0.46rem;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.08), 0 0 12px currentColor;
+}
+
+.obs-signal-dot--live {
+    color: #34d399;
+    animation: obs-pulse 2.6s ease-in-out infinite;
+}
+
+.obs-section-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 1.15rem;
+}
+
+.obs-section-title {
+    margin: 0.35rem 0 0;
+    color: var(--obs-text);
+    font-size: clamp(1.45rem, 2vw, 2rem);
+    font-weight: 680;
+    letter-spacing: -0.035em;
+}
+
+.obs-section-note {
+    color: var(--obs-muted);
+    font-size: 0.82rem;
+}
+
+.obs-panel,
+.obs-readout-card {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--obs-border);
+    background: var(--obs-panel);
+    box-shadow: var(--obs-shadow);
+    backdrop-filter: blur(20px);
+}
+
+.obs-panel {
+    border-radius: 1rem;
+    padding: clamp(1.1rem, 2vw, 1.5rem);
+}
+
+.obs-panel::before,
+.obs-readout-card::before {
+    position: absolute;
+    top: -1px;
+    left: 1.25rem;
+    width: 3.6rem;
+    height: 1px;
+    background: linear-gradient(90deg, var(--obs-cyan-bright), transparent);
+    content: "";
+}
+
+.obs-readout-card {
+    min-height: 18rem;
+    border-radius: 0.9rem;
+    padding: 1.25rem;
+    transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.obs-readout-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--obs-border-strong);
+    box-shadow: 0 26px 70px rgba(2, 8, 23, 0.15);
+}
+
+.obs-instrument-mark {
+    display: grid;
+    width: 2.75rem;
+    height: 2.75rem;
+    place-items: center;
+    border: 1px solid var(--obs-border-strong);
+    border-radius: 0.7rem;
+    background: linear-gradient(145deg, rgba(34, 211, 238, 0.11), rgba(99, 102, 241, 0.07));
+    color: var(--obs-cyan);
+}
+
+.obs-instrument-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+}
+
+.obs-readout-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: clamp(2.35rem, 4vw, 3.35rem);
+    font-weight: 600;
+    letter-spacing: -0.07em;
+    line-height: 1;
+}
+
+.obs-readout-unit {
+    margin-left: 0.3rem;
+    color: var(--obs-muted);
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.88rem;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.obs-chart-well,
+.obs-camera-well {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--obs-border);
+    border-radius: 0.8rem;
+    background:
+        linear-gradient(var(--obs-grid) 1px, transparent 1px),
+        linear-gradient(90deg, var(--obs-grid) 1px, transparent 1px),
+        var(--obs-panel-soft);
+    background-size: 28px 28px;
+}
+
+.obs-camera-well {
+    min-height: 22rem;
+    background-color: #030713;
+}
+
+.obs-camera-placeholder {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-content: center;
+    gap: 0.9rem;
+    padding: 2rem;
+    color: #71829b;
+    text-align: center;
+    transition: opacity 180ms ease;
+}
+
+.obs-camera-placeholder[hidden] {
+    display: none;
+}
+
+.obs-reticle {
+    position: relative;
+    width: 7rem;
+    height: 7rem;
+    margin-inline: auto;
+    border: 1px solid rgba(103, 232, 249, 0.28);
+    border-radius: 50%;
+    box-shadow: inset 0 0 35px rgba(34, 211, 238, 0.06), 0 0 25px rgba(34, 211, 238, 0.05);
+}
+
+.obs-reticle::before,
+.obs-reticle::after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    background: rgba(103, 232, 249, 0.25);
+    content: "";
+    transform: translate(-50%, -50%);
+}
+
+.obs-reticle::before { width: 8.5rem; height: 1px; }
+.obs-reticle::after { width: 1px; height: 8.5rem; }
+
+.obs-segmented {
+    display: inline-flex;
+    gap: 0.25rem;
+    border: 1px solid var(--obs-border);
+    border-radius: 0.7rem;
+    background: var(--obs-panel-soft);
+    padding: 0.25rem;
+}
+
+.obs-tab {
+    border: 0;
+    border-radius: 0.5rem;
+    background: transparent;
+    padding: 0.66rem 0.85rem;
+    color: var(--obs-muted);
+    font-size: 0.75rem;
+    font-weight: 750;
+    cursor: pointer;
+}
+
+.obs-tab[aria-selected="true"] {
+    background: var(--obs-panel-strong);
+    color: var(--obs-cyan);
+    box-shadow: 0 5px 18px rgba(2, 8, 23, 0.09);
+}
+
+.obs-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 2.25rem;
+    border: 1px solid rgba(251, 191, 36, 0.24);
+    border-radius: 999px;
+    background: rgba(245, 158, 11, 0.08);
+    padding: 0.45rem 0.75rem;
+    color: #fbbf24;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.66rem;
+    font-weight: 750;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.obs-status-pill::before {
+    width: 0.42rem;
+    height: 0.42rem;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 10px currentColor;
+    content: "";
+}
+
+.obs-status-pill--ok {
+    border-color: rgba(52, 211, 153, 0.26);
+    background: rgba(16, 185, 129, 0.08);
+    color: var(--obs-green);
+}
+
+.obs-status-pill--bad {
+    border-color: rgba(251, 113, 133, 0.28);
+    background: rgba(244, 63, 94, 0.08);
+    color: var(--obs-red);
+}
+
+.obs-status-pill--warn {
+    border-color: rgba(251, 191, 36, 0.24);
+    background: rgba(245, 158, 11, 0.08);
+    color: #f59e0b;
+}
+
+.obs-panel:fullscreen {
+    overflow: auto;
+    border-radius: 0;
+    background: var(--obs-canvas);
+    padding: 2rem;
+}
+
+.obs-page-hero {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(103, 232, 249, 0.18);
+    border-radius: 1.15rem;
+    background:
+        radial-gradient(circle at 86% 10%, rgba(79, 70, 229, 0.28), transparent 20rem),
+        linear-gradient(135deg, #07101f, #0b1730);
+    padding: clamp(1.6rem, 4vw, 3rem);
+    color: #f8fafc;
+    box-shadow: var(--obs-shadow);
+}
+
+.obs-page-hero::after {
+    position: absolute;
+    top: -9rem;
+    right: -5rem;
+    width: 23rem;
+    height: 23rem;
+    border: 1px solid rgba(103, 232, 249, 0.15);
+    border-radius: 50%;
+    content: "";
+}
+
+.obs-page-hero > * {
+    position: relative;
+    z-index: 1;
+}
+
+@keyframes obs-pulse {
+    0%, 100% { opacity: 0.6; transform: scale(0.92); }
+    50% { opacity: 1; transform: scale(1); }
+}
+
+@media (max-width: 900px) {
+    .obs-hero-grid {
+        grid-template-columns: 1fr;
+        align-items: end;
+    }
+
+    .obs-hero-metric {
+        max-width: 22rem;
+    }
+}
+
+@media (max-width: 680px) {
+    .obs-frame {
+        width: min(100% - 1rem, 88rem);
+        padding-top: 0.5rem;
+    }
+
+    .obs-topbar {
+        align-items: flex-start;
+        border-radius: 0.85rem;
+    }
+
+    .obs-brand-kicker,
+    .obs-nav-label {
+        display: none;
+    }
+
+    .obs-hero {
+        min-height: 0;
+        border-radius: 1rem;
+    }
+
+    .obs-hero-grid {
+        min-height: 0;
+        padding: 2rem 1.3rem;
+    }
+
+    .obs-hero-footer {
+        grid-template-columns: 1fr;
+    }
+
+    .obs-hero-footer-item + .obs-hero-footer-item {
+        border-top: 1px solid rgba(148, 163, 184, 0.16);
+        border-left: 0;
+    }
+
+    .obs-section-head {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.45rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}


### PR DESCRIPTION
## What changed

- Introduces a cohesive professional observatory-console visual system across the live dashboard, archive, history, and Home Assistant wall display.
- Adds restrained orbital geometry, telemetry typography, cyan/violet signal accents, responsive instrument panels, and improved disconnected/loading states.
- Preserves MQTT sensor cards, the all-sky camera, historical views, CSV downloads, chart tabs, and light/dark modes.
- Adds Highcharts accessibility descriptions and a fallback year in the archive when the database is unavailable.

## Why

The previous interface was functionally strong but visually generic. This change makes the observatory feel distinctive and space-age while keeping the information hierarchy calm, operational, and readable.

## Validation

- PHP syntax checks passed for `layout.php`, `index.php`, `clear.php`, `historical.php`, and `HA.php`.
- All four pages returned HTTP 200 in the local PHP server.
- Desktop and mobile visual QA passed with no horizontal overflow.
- Light/dark themes and chart-tab interactions were verified in-browser.
- `git diff --check` passed.